### PR TITLE
Fix: Angular material css import

### DIFF
--- a/app/less/main.less
+++ b/app/less/main.less
@@ -7,7 +7,7 @@
 /**
  * import less files from libraries such as bootstrap here
  */
-@import "../components/angular-material/angular-material.css";
+@import (inline) "../components/angular-material/angular-material.css";
 
 
 


### PR DESCRIPTION
Fixes an issue where the `angular-material.css` was not being imported into `main.less` properly