### PR TITLE
Fix: transport

### DIFF
--- a/app/js/fm-api/factories/PlayerTransportResource.js
+++ b/app/js/fm-api/factories/PlayerTransportResource.js
@@ -21,6 +21,13 @@ angular.module("sn.fm.api").factory("PlayerTransportResource", [
             // Hash with declaration of custom action that should
             // extend the default set of resource actions
             {
+                get: {
+                    method: "GET",
+                    transformResponse: function (data, headers){
+                        data.paused = !!parseInt(headers("Paused"), 10);
+                        return data;
+                    }
+                },
                 pause: {
                     method: "POST",
                     url: FM_API_SERVER_ADDRESS + "player/pause"

--- a/app/js/fm-player/config.js
+++ b/app/js/fm-player/config.js
@@ -27,7 +27,7 @@ angular.module("sn.fm.player").config([
                         return PlayerQueueResource.query($route.current.params);
                     }],
                     currentTrack: ["PlayerTransportResource", function (PlayerTransportResource){
-                        return PlayerTransportResource.get({});
+                        return PlayerTransportResource.get();
                     }],
                     PlayerMuteResource: ["PlayerMuteResource", function (PlayerMuteResource){
                         return PlayerMuteResource.get();

--- a/app/js/fm-player/config.js
+++ b/app/js/fm-player/config.js
@@ -26,8 +26,17 @@ angular.module("sn.fm.player").config([
                     playlistData: ["PlayerQueueResource", "$route", function (PlayerQueueResource, $route){
                         return PlayerQueueResource.query($route.current.params);
                     }],
-                    currentTrack: ["PlayerTransportResource", function (PlayerTransportResource){
-                        return PlayerTransportResource.get();
+                    currentTrack: ["$q", "PlayerTransportResource", function ($q, PlayerTransportResource){
+                        var deferred = $q.defer();
+
+                        PlayerTransportResource.get({}, function(data, headers){
+                            deferred.resolve({
+                                track: data,
+                                paused: headers("Paused")
+                            });
+                        });
+
+                        return deferred.promise;
                     }],
                     PlayerMuteResource: ["PlayerMuteResource", function (PlayerMuteResource){
                         return PlayerMuteResource.get();

--- a/app/js/fm-player/config.js
+++ b/app/js/fm-player/config.js
@@ -26,17 +26,8 @@ angular.module("sn.fm.player").config([
                     playlistData: ["PlayerQueueResource", "$route", function (PlayerQueueResource, $route){
                         return PlayerQueueResource.query($route.current.params);
                     }],
-                    currentTrack: ["$q", "PlayerTransportResource", function ($q, PlayerTransportResource){
-                        var deferred = $q.defer();
-
-                        PlayerTransportResource.get({}, function(data, headers){
-                            deferred.resolve({
-                                track: data,
-                                paused: headers("Paused")
-                            });
-                        });
-
-                        return deferred.promise;
+                    currentTrack: ["PlayerTransportResource", function (PlayerTransportResource){
+                        return PlayerTransportResource.get({});
                     }],
                     PlayerMuteResource: ["PlayerMuteResource", function (PlayerMuteResource){
                         return PlayerMuteResource.get();

--- a/app/js/fm-player/controllers/PlayerCtrl.js
+++ b/app/js/fm-player/controllers/PlayerCtrl.js
@@ -40,15 +40,6 @@ angular.module("sn.fm.player").controller("PlayerCtrl", [
         $scope.playlist = playlistData;
 
         /**
-         * An instance of the $resource PlayerTransportResource
-         * which provides player transport operations and information
-         * about the currently playing track
-         * @property transport
-         * @type     {Object}
-         */
-        $scope.transport = PlayerTransportResource;
-
-        /**
          * The currently playing track
          * @property current
          * @type     {Object}
@@ -69,6 +60,24 @@ angular.module("sn.fm.player").controller("PlayerCtrl", [
          * @type     {Object}
          */
         $scope.mute = PlayerMuteResource;
+
+        /**
+         * Set paused state and send request to API
+         * @method resume
+         */
+        $scope.resume = function resume() {
+            $scope.paused = false;
+            PlayerTransportResource.resume();
+        };
+
+        /**
+         * Set paused state and send request to API
+         * @method pause
+         */
+        $scope.pause = function pause() {
+            $scope.paused = true;
+            PlayerTransportResource.pause({});
+        };
 
         /**
          * Increment volume by 10

--- a/app/js/fm-player/controllers/PlayerCtrl.js
+++ b/app/js/fm-player/controllers/PlayerCtrl.js
@@ -44,14 +44,14 @@ angular.module("sn.fm.player").controller("PlayerCtrl", [
          * @property current
          * @type     {Object}
          */
-        $scope.current = currentTrack;
+        $scope.current = currentTrack.track;
 
         /**
          * Tracks the state of playback
          * @property paused
          * @type     {Boolean}
          */
-        $scope.paused = false;
+        $scope.paused = currentTrack.paused;
 
         /**
          * An instance of the $resource PlayerMuteResource
@@ -179,7 +179,9 @@ angular.module("sn.fm.player").controller("PlayerCtrl", [
          * @method init
          */
         $scope.init = function init() {
-            $scope.playlist.unshift($scope.current);
+            if ($scope.current.id){
+                $scope.playlist.unshift($scope.current);
+            }
         };
 
         /**

--- a/app/js/fm-player/controllers/PlayerCtrl.js
+++ b/app/js/fm-player/controllers/PlayerCtrl.js
@@ -44,7 +44,7 @@ angular.module("sn.fm.player").controller("PlayerCtrl", [
          * @property current
          * @type     {Object}
          */
-        $scope.current = currentTrack.track;
+        $scope.current = currentTrack;
 
         /**
          * Tracks the state of playback

--- a/app/partials/player.html
+++ b/app/partials/player.html
@@ -92,10 +92,10 @@
                                 </h4>
                             </div>
                             <span ng-if="$first" class="md-tile-right">
-                                <md-button class="md-fab md-primary" aria-label="Play" ng-show="paused" ng-click="transport.resume()">
+                                <md-button class="md-fab md-primary" aria-label="Play" ng-show="paused" ng-click="resume()">
                                     <md-icon md-svg-src="img/icons/ic_play_arrow_24px.svg"></md-icon>
                                 </md-button>
-                                <md-button class="md-fab md-primary" aria-label="Pause" ng-show="!paused" ng-click="transport.pause({})">
+                                <md-button class="md-fab md-primary" aria-label="Pause" ng-show="!paused" ng-click="pause()">
                                     <md-icon md-svg-src="img/icons/ic_pause_24px.svg"></md-icon>
                                 </md-button>
 <!--

--- a/tests/unit/fm-api/factories/PlayerTransportResource.js
+++ b/tests/unit/fm-api/factories/PlayerTransportResource.js
@@ -1,0 +1,25 @@
+"use strict";
+
+describe("sn.fm.api:PlayerTransportResource", function (){
+    var $httpBackend, PlayerTransportResource;
+
+    beforeEach(function (){
+        module("sn.fm.api");
+    });
+
+    beforeEach(inject(function ( $injector, $resource ){
+        $httpBackend = $injector.get("$httpBackend");
+        PlayerTransportResource = $injector.get("PlayerTransportResource");
+
+        $httpBackend.whenGET(/.*player\/current/).respond(200, { "name": "some track name" }, { "Paused": 1 });
+    }));
+
+    it("should add paused header to data", function(){
+        var response = PlayerTransportResource.get();
+        $httpBackend.flush();
+        expect(response.paused).toEqual(true);
+        expect(response.name).toEqual("some track name");
+    });
+
+});
+

--- a/tests/unit/fm-player/controllers/PlayerCtrl.js
+++ b/tests/unit/fm-player/controllers/PlayerCtrl.js
@@ -4,7 +4,7 @@ describe("sn.fm.player:PlayerCtrl", function() {
 
     var $scope, $q, Spotify, PlayerMuteResource, PlayerQueueResource, PlayerTransportResource, PlayerVolumeResource, TracksResource,
         spotifyCallback, queueCallback, trackCallback, volumeCallback, mockPlayerVolumeResource,
-        _track, _volumeInstance, _playlistData, _currentTrack, _initialVolume, _initialMute;
+        _track, _volumeInstance, _playlistData, _currentTrack;
 
     beforeEach(function (){
         module("sn.fm.player");
@@ -65,6 +65,8 @@ describe("sn.fm.player:PlayerCtrl", function() {
 
         PlayerTransportResource = $injector.get("PlayerTransportResource");
         spyOn(PlayerTransportResource, "get").and.callFake(trackCallback);
+        spyOn(PlayerTransportResource, "resume");
+        spyOn(PlayerTransportResource, "pause");
 
         PlayerVolumeResource = $injector.get("PlayerVolumeResource");
         spyOn(PlayerVolumeResource, "get").and.callFake(mockPlayerVolumeResource);
@@ -206,6 +208,18 @@ describe("sn.fm.player:PlayerCtrl", function() {
         var track = { uri: "foo" };
         $scope.onTrackSelected(track);
         expect(PlayerQueueResource.save).toHaveBeenCalledWith(track);
+    });
+
+    it("should set pause state true and make call to PlayerTransportResource.pause", function() {
+        $scope.pause();
+        expect(PlayerTransportResource.pause).toHaveBeenCalledWith({});
+        expect($scope.paused).toEqual(true);
+    });
+
+    it("should set pause state false and make call to PlayerTransportResource.resume", function() {
+        $scope.resume();
+        expect(PlayerTransportResource.resume).toHaveBeenCalledWith();
+        expect($scope.paused).toEqual(false);
     });
 
     describe("volumeUp", function() {

--- a/tests/unit/fm-player/controllers/PlayerCtrl.js
+++ b/tests/unit/fm-player/controllers/PlayerCtrl.js
@@ -4,7 +4,7 @@ describe("sn.fm.player:PlayerCtrl", function() {
 
     var $scope, $q, Spotify, PlayerMuteResource, PlayerQueueResource, PlayerTransportResource, PlayerVolumeResource, TracksResource,
         spotifyCallback, queueCallback, trackCallback, volumeCallback, mockPlayerVolumeResource,
-        _track, _volumeInstance, _playlistData, _currentTrack;
+        _volumeInstance, _playlistData, _currentTrack;
 
     beforeEach(function (){
         module("sn.fm.player");
@@ -39,7 +39,7 @@ describe("sn.fm.player:PlayerCtrl", function() {
             return {
                 $promise: {
                     then: function(fn){
-                        fn.apply(this,[_track])
+                        fn.apply(this,[_currentTrack])
                     }
                 }
             }
@@ -133,7 +133,7 @@ describe("sn.fm.player:PlayerCtrl", function() {
             "spotify_uri" : "spotify:track:3dOAXUx7I1qnzWzxdnsyB8"
         }]
 
-        _track = {
+        _currentTrack = {
             "album": {
                 "artists": [
                     {
@@ -166,12 +166,8 @@ describe("sn.fm.player:PlayerCtrl", function() {
             "duration": 272906,
             "id": "4b170737-017c-4e85-965c-47b8a158c789",
             "name": "Dark Chest Of Wonders - Live @ Wacken 2013",
-            "spotify_uri": "spotify:track:6FshvOVICpRVkwpYE5BYTD"
-        }
-
-        _currentTrack = {
-            track: _track,
-            paused: 0
+            "spotify_uri": "spotify:track:6FshvOVICpRVkwpYE5BYTD",
+            "paused": 0
         }
 
         $controller("PlayerCtrl", {
@@ -195,12 +191,12 @@ describe("sn.fm.player:PlayerCtrl", function() {
 
     it("should attach resolved data to scope", function() {
         expect($scope.playlist).toEqual(_playlistData);
-        expect($scope.current).toEqual(_currentTrack.track);
+        expect($scope.current).toEqual(_currentTrack);
         expect($scope.paused).toEqual(_currentTrack.paused);
     });
 
     it("should add current track to playlist on init", function() {
-        expect($scope.playlist[0]).toEqual(_currentTrack.track);
+        expect($scope.playlist[0]).toEqual(_currentTrack);
         expect($scope.playlist.length).toEqual(3);
     });
 
@@ -307,19 +303,19 @@ describe("sn.fm.player:PlayerCtrl", function() {
         });
 
         it("should update playlist", function(){
-            _playlistData.unshift(_currentTrack.track);
+            _playlistData.unshift(_currentTrack);
             expect($scope.playlist).toEqual(_playlistData);
         });
 
         it("should update current", function(){
-            expect($scope.current).toEqual(_currentTrack.track);
+            expect($scope.current).toEqual(_currentTrack);
         });
     });
 
     describe("socket event handling", function(){
 
         it("should update playlist on end event", function() {
-            var eventData = { uri: _currentTrack.track.spotify_uri },
+            var eventData = { uri: _currentTrack.spotify_uri },
                 expectLength = $scope.playlist.length - 1;
 
             $scope.$broadcast("fm:player:end", eventData);
@@ -370,7 +366,7 @@ describe("sn.fm.player:PlayerCtrl", function() {
 
             $scope.$broadcast("fm:player:add", eventData);
             expect($scope.playlist.length).toEqual(4);
-            expect($scope.playlist[3]).toEqual(_track);
+            expect($scope.playlist[3]).toEqual(_currentTrack);
         });
 
         it("should set mute state on setMute event", function() {

--- a/tests/unit/fm-player/controllers/PlayerCtrl.js
+++ b/tests/unit/fm-player/controllers/PlayerCtrl.js
@@ -4,7 +4,7 @@ describe("sn.fm.player:PlayerCtrl", function() {
 
     var $scope, $q, Spotify, PlayerMuteResource, PlayerQueueResource, PlayerTransportResource, PlayerVolumeResource, TracksResource,
         spotifyCallback, queueCallback, trackCallback, volumeCallback, mockPlayerVolumeResource,
-        _volumeInstance, _playlistData, _currentTrack, _initialVolume, _initialMute;
+        _track, _volumeInstance, _playlistData, _currentTrack, _initialVolume, _initialMute;
 
     beforeEach(function (){
         module("sn.fm.player");
@@ -39,7 +39,7 @@ describe("sn.fm.player:PlayerCtrl", function() {
             return {
                 $promise: {
                     then: function(fn){
-                        fn.apply(this,[_currentTrack])
+                        fn.apply(this,[_track])
                     }
                 }
             }
@@ -131,7 +131,7 @@ describe("sn.fm.player:PlayerCtrl", function() {
             "spotify_uri" : "spotify:track:3dOAXUx7I1qnzWzxdnsyB8"
         }]
 
-        _currentTrack = {
+        _track = {
             "album": {
                 "artists": [
                     {
@@ -167,6 +167,11 @@ describe("sn.fm.player:PlayerCtrl", function() {
             "spotify_uri": "spotify:track:6FshvOVICpRVkwpYE5BYTD"
         }
 
+        _currentTrack = {
+            track: _track,
+            paused: 0
+        }
+
         $controller("PlayerCtrl", {
             $scope: $scope,
             $q: $q,
@@ -188,11 +193,12 @@ describe("sn.fm.player:PlayerCtrl", function() {
 
     it("should attach resolved data to scope", function() {
         expect($scope.playlist).toEqual(_playlistData);
-        expect($scope.current).toEqual(_currentTrack);
+        expect($scope.current).toEqual(_currentTrack.track);
+        expect($scope.paused).toEqual(_currentTrack.paused);
     });
 
     it("should add current track to playlist on init", function() {
-        expect($scope.playlist[0]).toEqual(_currentTrack);
+        expect($scope.playlist[0]).toEqual(_currentTrack.track);
         expect($scope.playlist.length).toEqual(3);
     });
 
@@ -287,19 +293,19 @@ describe("sn.fm.player:PlayerCtrl", function() {
         });
 
         it("should update playlist", function(){
-            _playlistData.unshift(_currentTrack);
+            _playlistData.unshift(_currentTrack.track);
             expect($scope.playlist).toEqual(_playlistData);
         });
 
         it("should update current", function(){
-            expect($scope.current).toEqual(_currentTrack);
+            expect($scope.current).toEqual(_currentTrack.track);
         });
     });
 
     describe("socket event handling", function(){
 
         it("should update playlist on end event", function() {
-            var eventData = { uri: _currentTrack.spotify_uri },
+            var eventData = { uri: _currentTrack.track.spotify_uri },
                 expectLength = $scope.playlist.length - 1;
 
             $scope.$broadcast("fm:player:end", eventData);
@@ -350,7 +356,7 @@ describe("sn.fm.player:PlayerCtrl", function() {
 
             $scope.$broadcast("fm:player:add", eventData);
             expect($scope.playlist.length).toEqual(4);
-            expect($scope.playlist[3]).toEqual(_currentTrack);
+            expect($scope.playlist[3]).toEqual(_track);
         });
 
         it("should set mute state on setMute event", function() {


### PR DESCRIPTION
This PR resolves current playback state from paused header on response from `/player/current` resource. Also adds explicit resume/pause functions on scope.