### PR TITLE
Fix: resolve promises

### DIFF
--- a/app/js/fm-player/config.js
+++ b/app/js/fm-player/config.js
@@ -24,13 +24,13 @@ angular.module("sn.fm.player").config([
                 controller: "PlayerCtrl",
                 resolve: {
                     playlistData: ["PlayerQueueResource", "$route", function (PlayerQueueResource, $route){
-                        return PlayerQueueResource.query($route.current.params);
+                        return PlayerQueueResource.query($route.current.params).$promise;
                     }],
                     currentTrack: ["PlayerTransportResource", function (PlayerTransportResource){
-                        return PlayerTransportResource.get();
+                        return PlayerTransportResource.get().$promise;
                     }],
                     PlayerMuteResource: ["PlayerMuteResource", function (PlayerMuteResource){
-                        return PlayerMuteResource.get();
+                        return PlayerMuteResource.get().$promise;
                     }]
                 }
             })

--- a/app/js/fm-player/controllers/PlayerCtrl.js
+++ b/app/js/fm-player/controllers/PlayerCtrl.js
@@ -165,7 +165,7 @@ angular.module("sn.fm.player").controller("PlayerCtrl", [
          */
         $scope.refreshPlaylist = function refreshPlaylistQueue(){
             $q.all([
-                PlayerQueueResource.get().$promise,
+                PlayerQueueResource.query().$promise,
                 PlayerTransportResource.get().$promise
             ]).then(function(response){
                 $scope.playlist = response[0];

--- a/tests/unit/fm-player/controllers/PlayerCtrl.js
+++ b/tests/unit/fm-player/controllers/PlayerCtrl.js
@@ -61,7 +61,7 @@ describe("sn.fm.player:PlayerCtrl", function() {
 
         PlayerQueueResource = $injector.get("PlayerQueueResource");
         spyOn(PlayerQueueResource, "save");
-        spyOn(PlayerQueueResource, "get").and.callFake(queueCallback);
+        spyOn(PlayerQueueResource, "query").and.callFake(queueCallback);
 
         PlayerTransportResource = $injector.get("PlayerTransportResource");
         spyOn(PlayerTransportResource, "get").and.callFake(trackCallback);
@@ -298,7 +298,7 @@ describe("sn.fm.player:PlayerCtrl", function() {
         });
 
         it("should make request to Queue and Transport resource", function() {
-            expect(PlayerQueueResource.get).toHaveBeenCalledWith();
+            expect(PlayerQueueResource.query).toHaveBeenCalledWith();
             expect(PlayerTransportResource.get).toHaveBeenCalledWith();
         });
 


### PR DESCRIPTION
This PR corrects the resolve config by returning the `$promise` rather than resource instance.