### PR TITLE
Feature: Phonegap build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,6 +16,7 @@ module.exports = function (grunt) {
 
         config: {
             outputDir: "dist/",
+            env: grunt.file.readJSON("env.json")[env],
             applicationFiles: grunt.file.readJSON("scripts.json").application,
             vendorFiles: grunt.file.readJSON("scripts.json").vendor
         },
@@ -252,7 +253,10 @@ module.exports = function (grunt) {
 
         processhtml: {
             options: {
-                strip: true
+                strip: true,
+                data: {
+                    url: "<%= config.env.BASE_URL %>"
+                }
             },
             production: {
                 files: {
@@ -297,7 +301,7 @@ module.exports = function (grunt) {
             options: {
                 name: "ENV",
                 dest: "app/js/env/env.js",
-                constants: grunt.file.readJSON("env.json")[env]
+                constants: "<%= config.env %>"
             },
             dist: {}
         },

--- a/app/index.html
+++ b/app/index.html
@@ -3,22 +3,22 @@
 <html lang="en" ng-app="sn.fm" ng-strict-di>
 <!-- /build -->
     <head>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
-        <meta name="fragment" content="!"/>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+        <meta name="fragment" content="!">
         <title>thisissoon.fm</title>
 
         <!-- build:template
-        <base href="/"/>
+        <base href="<%= url %>">
         /build -->
         <!-- build:remove -->
-        <base href="/app/"/>
+        <base href="/app/">
         <!-- /build -->
 
         <!-- build:css css/all.min.css -->
-        <link rel="stylesheet" href="css/all.css"/>
+        <link rel="stylesheet" href="css/all.css">
         <!-- /build -->
-        <link rel="shortcut icon" type="image/png" href="img/icons/favicon-16x16.png"/>
+        <link rel="shortcut icon" type="image/png" href="img/icons/favicon-16x16.png">
     </head>
     <body>
 

--- a/app/index.html
+++ b/app/index.html
@@ -6,7 +6,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
         <meta name="fragment" content="!">
-        <title>thisissoon.fm</title>
+        <title>SOON_ FM</title>
 
         <!-- build:template
         <base href="<%= url %>">

--- a/app/js/fm-player/app.js
+++ b/app/js/fm-player/app.js
@@ -11,7 +11,7 @@
  * @requires spotify    {@link https://github.com/eddiemoore/angular-spotify}
  * @requires sn.fm.api
  */
-angular.module("sn.fm.player", ["ngRoute", "ngMaterial", "spotify", "sn.fm.api"])
+angular.module("sn.fm.player", ["ENV", "ngRoute", "ngMaterial", "spotify", "sn.fm.api"])
 
 .run([
     "$rootScope",

--- a/app/js/fm-player/config.js
+++ b/app/js/fm-player/config.js
@@ -9,14 +9,18 @@
 angular.module("sn.fm.player").config([
     "$routeProvider",
     "$locationProvider",
+    "HTML5_LOCATION",
     /**
      * @constructor
      * @param {Service} $routeProvider
      * @param {Service} $locationProvider
+     * @param {Boolean} HTML5_LOCATION
      */
-    function ($routeProvider, $locationProvider) {
+    function ($routeProvider, $locationProvider, HTML5_LOCATION) {
 
-        $locationProvider.html5Mode(true).hashPrefix = "!";
+        if (HTML5_LOCATION) {
+            $locationProvider.html5Mode(true).hashPrefix = "!";
+        }
 
         $routeProvider
             .when("/", {

--- a/app/less/default/modules/menu.less
+++ b/app/less/default/modules/menu.less
@@ -22,7 +22,7 @@
 .header-menu h1 {
     font-size: 1.250em;
     font-weight: 400;
-    margin: auto;
+    margin: auto auto auto 60px;
 }
 
 .md-sidenav-left {

--- a/app/less/main.less
+++ b/app/less/main.less
@@ -50,7 +50,7 @@
  *      @import "tablet/modules/article.less";
  */
 @media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
-
+    @import "tablet/modules/menu.less";
 }
 
 /**

--- a/app/less/tablet/modules/menu.less
+++ b/app/less/tablet/modules/menu.less
@@ -7,7 +7,3 @@
 .logo {
     display: none
 }
-
-.header-menu h1 {
-    font-size: .9em;
-}

--- a/app/partials/player.html
+++ b/app/partials/player.html
@@ -1,7 +1,7 @@
 <md-toolbar layout="row" class="header-menu">
 
     <button ng-click="toggleSideNav('left')"
-            hide-gt-sm
+            hide-gt-md
             class="btn-menu">
         <md-icon md-svg-src="img/icons/ic_playlist_add_48px.svg"></md-icon>
     </button>
@@ -34,7 +34,7 @@
         layout="column"
         class="md-sidenav-left md-whiteframe-z2"
         md-component-id="left"
-        md-is-locked-open="$mdMedia('gt-sm')"
+        md-is-locked-open="$mdMedia('gt-md')"
         md-swipe-left="closeSideNav('left')"
     >
         <md-autocomplete

--- a/env.json
+++ b/env.json
@@ -6,7 +6,7 @@
         "HTML5_LOCATION": true
     },
     "production": {
-        "BASE_URL": "http://thisissoon.com/",
+        "BASE_URL": "http://thisissoon.fm/",
         "FM_API_SERVER_ADDRESS": "http://api.thisissoon.fm/",
         "FM_SOCKET_ADDRESS": "http://sockets.thisissoon.fm/",
         "HTML5_LOCATION": true

--- a/env.json
+++ b/env.json
@@ -1,10 +1,20 @@
 {
     "development": {
+        "BASE_URL": "/",
         "FM_API_SERVER_ADDRESS": "http://localdocker:5000/",
-        "FM_SOCKET_ADDRESS": "http://localdocker:8080"
+        "FM_SOCKET_ADDRESS": "http://localdocker:8080",
+        "HTML5_LOCATION": true
     },
     "production": {
+        "BASE_URL": "http://thisissoon.com/",
         "FM_API_SERVER_ADDRESS": "http://api.thisissoon.fm/",
-        "FM_SOCKET_ADDRESS": "http://sockets.thisissoon.fm/"
+        "FM_SOCKET_ADDRESS": "http://sockets.thisissoon.fm/",
+        "HTML5_LOCATION": true
+    },
+    "phonegap": {
+        "BASE_URL": "./",
+        "FM_API_SERVER_ADDRESS": "http://api.thisissoon.fm/",
+        "FM_SOCKET_ADDRESS": "http://sockets.thisissoon.fm/",
+        "HTML5_LOCATION": false
     }
 }


### PR DESCRIPTION
This PR allows us to build a version of the FM frontend for phonegap by simply running `grunt build -env phonegap`.

I've added a `phonegap` environment in the environment config `env.json` and added the options needed to configure the app.