### PR TITLE
Fix: naming conflict, rename EVENTS => FM_SOCKET_EVENTS

### DIFF
--- a/app/js/fm-loading-screen/loadingScreen.js
+++ b/app/js/fm-loading-screen/loadingScreen.js
@@ -7,10 +7,10 @@
 angular.module("sn.fm.loadingScreen", [])
 /**
  * @constant
- * @property EVENTS
+ * @property ROUTE_EVENTS
  * @type {Object}
  */
-.constant("EVENTS", {
+.constant("ROUTE_EVENTS", {
     ROUTE_CHANGE_START: "$routeChangeStart",
     ROUTE_CHANGE_SUCCESS: "$routeChangeSuccess",
     ROUTE_CHANGE_ERROR: "$routeChangeError"
@@ -25,13 +25,13 @@ angular.module("sn.fm.loadingScreen", [])
  */
 .directive("fmLoadingScreen",[
     "$rootScope",
-    "EVENTS",
+    "ROUTE_EVENTS",
     /**
      * @constructor
      * @param {Service} $rootScope
-     * @param {Object}  EVENTS
+     * @param {Object}  ROUTE_EVENTS
      */
-    function ($rootScope, EVENTS){
+    function ($rootScope, ROUTE_EVENTS){
         return {
             restrict: "EA",
             templateUrl: "partials/loading.html",
@@ -53,9 +53,9 @@ angular.module("sn.fm.loadingScreen", [])
                     $element.addClass("hide");
                 };
 
-                $rootScope.$on(EVENTS.ROUTE_CHANGE_START, show);
-                $rootScope.$on(EVENTS.ROUTE_CHANGE_SUCCESS, hide);
-                $rootScope.$on(EVENTS.ROUTE_CHANGE_ERROR, hide);
+                $rootScope.$on(ROUTE_EVENTS.ROUTE_CHANGE_START, show);
+                $rootScope.$on(ROUTE_EVENTS.ROUTE_CHANGE_SUCCESS, hide);
+                $rootScope.$on(ROUTE_EVENTS.ROUTE_CHANGE_ERROR, hide);
 
             }
         };

--- a/app/js/fm-socket/socket.js
+++ b/app/js/fm-socket/socket.js
@@ -18,24 +18,24 @@ angular.module("sn.fm.sockets", [
 
     .run([
         "fmSocket",
-        "EVENTS",
+        "FM_SOCKET_EVENTS",
         /**
          * @constructor
          * @param {Factory} fmSocket socket instance
-         * @param {Array}   EVENTS   list of available socket events
+         * @param {Array}   FM_SOCKET_EVENTS   list of available socket events
          */
-        function(fmSocket, EVENTS){
+        function(fmSocket, FM_SOCKET_EVENTS){
             /**
              * Forwards all fm.socket events to angular event system
              */
-            fmSocket.forward(EVENTS);
+            fmSocket.forward(FM_SOCKET_EVENTS);
         }
     ])
 
     /**
      * @constant {Array} list of available socket events
      */
-    .constant("EVENTS", [
+    .constant("FM_SOCKET_EVENTS", [
         "fm:player:play",
         "fm:player:end",
         "fm:player:pause",


### PR DESCRIPTION
The EVENTS constant used in fm-socket was conflicting with EVENTS constant declared in fm-loading-screen. I have now namespaced this as `FM_SOCKET_EVENTS`