### PR TITLE
Feature: auth integration

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -202,12 +202,7 @@ module.exports = function (grunt) {
             },
             production: {
                 files: {
-                    "<%= config.outputDir %>js/app.min.js":
-                    [
-                        "<%= config.vendorFiles %>",
-                        "<%= ngconstant.options.dest %>",
-                        "<%= config.applicationFiles %>"
-                    ]
+                    "<%= config.outputDir %>js/app.min.js": "<%= config.outputDir %>js/app.js"
                 }
             }
         },
@@ -329,6 +324,7 @@ module.exports = function (grunt) {
         "clean:beforeBuild",
         "less:production",
         "ngconstant",
+        "concat",
         "uglify",
         "copyBuild",
         "processhtml:production"
@@ -370,6 +366,7 @@ module.exports = function (grunt) {
         "clean:beforeBuild",
         "ngconstant",
         "jshint",
+        "concat",
         "uglify",
         "jasmine:production"
     ]);
@@ -383,6 +380,7 @@ module.exports = function (grunt) {
     grunt.registerTask("e2e", [
         "ngconstant",
         "less:production",
+        "concat",
         "uglify",
         "copy",
         "processhtml:e2e",

--- a/app/index.html
+++ b/app/index.html
@@ -37,6 +37,7 @@
         <script src="components/angular-resource/angular-resource.js"></script>
         <script src="components/angular-spotify/src/angular-spotify.js"></script>
         <script src="components/angular-socket-io/socket.js"></script>
+        <script src="components/satellizer/satellizer.js"></script>
 
         <script src="js/env/env.js"></script>
 

--- a/app/js/fm-api/app.js
+++ b/app/js/fm-api/app.js
@@ -8,4 +8,4 @@
  * @requires ENV        Angular environment variables
  * @requires ngResource {@link https://docs.angularjs.org/api/ngResource}
  */
-angular.module("sn.fm.api", ["ENV", "ngResource"]);
+angular.module("sn.fm.api", ["ENV", "ngResource", "satellizer"]);

--- a/app/js/fm-api/config.js
+++ b/app/js/fm-api/config.js
@@ -7,12 +7,33 @@
  */
 angular.module("sn.fm.api").config([
     "$httpProvider",
-    function ($httpProvider) {
+    "$authProvider",
+    "FM_API_SERVER_ADDRESS",
+    "BASE_URL",
+    "GOOGLE_CLIENT_ID",
+    /**
+     * @constructor
+     * @param {Service}  $httpProvider
+     * @param {Service}  $authProvider
+     * @param {String}   FM_API_SERVER_ADDRESS
+     * @param {String}   BASE_URL
+     * @param {String}   GOOGLE_CLIENT_ID
+     */
+    function ($httpProvider, $authProvider, FM_API_SERVER_ADDRESS, BASE_URL, GOOGLE_CLIENT_ID) {
 
         $httpProvider.defaults.headers.common["Content-Type"] = "application/json; charset=utf-8";
         $httpProvider.interceptors.push("RequestInterceptor");
 
+        $authProvider.httpInterceptor = false;
+        $authProvider.tokenName = "access_token";
+        $authProvider.tokenPrefix = "sn_fm";
+        $authProvider.authHeader = "Access-Token";
+        $authProvider.google({
+            url: FM_API_SERVER_ADDRESS + "oauth2/google/connect",
+            clientId: GOOGLE_CLIENT_ID,
+            redirectUri: BASE_URL,
+            scope: "https://www.googleapis.com/auth/plus.login https://www.googleapis.com/auth/plus.me https://www.googleapis.com/auth/plus.profiles.read email"
+        });
+
     }
-
-
 ]);

--- a/app/js/fm-api/factories/RequestInterceptor.js
+++ b/app/js/fm-api/factories/RequestInterceptor.js
@@ -1,22 +1,50 @@
 "use strict";
 /**
- * Intercepts all api requests to perform actions on the FE
- * if the api returns certain status codes e.g. navigate to
- * 500 page if server returns 500 code for any request.
  * @class RequestInterceptor
  */
 angular.module("sn.fm.api").factory("RequestInterceptor", [
     "$q",
     "$location",
+    "satellizer.config",
+    "FM_API_SERVER_ADDRESS",
     /**
      * @constructor
      * @param {Service} $q
      * @param {Service} $location
+     * @param {Object}  config                   satellizer configuration
+     * @param {String}  FM_API_SERVER_ADDRESS    API server url
      */
-    function ($q, $location) {
+    function ($q, $location, config, FM_API_SERVER_ADDRESS) {
 
         return {
 
+            /**
+             * Intercepts FM API requests to add auth header
+             * @param   {Object}   httpConfig
+             * @returns {Object} modified httpConfig
+             */
+            request: function(httpConfig) {
+
+                var tokenName = config.tokenPrefix ? config.tokenPrefix + "_" + config.tokenName : config.tokenName;
+
+                if(httpConfig.url.match(FM_API_SERVER_ADDRESS)) {
+
+                    var token = localStorage.getItem(tokenName);
+                    if (token) {
+                        httpConfig.headers[config.authHeader] = token;
+                    }
+
+                }
+
+                return httpConfig;
+            },
+
+            /**
+             * Intercepts all api requests to perform actions on the FE
+             * if the api returns certain status codes e.g. navigate to
+             * 500 page if server returns 500 code for any request.
+             * @param {Object} response
+             */
             responseError: function(response) {
                 if (response.status < 200 || response.status > 299){
                     $location.path("/500");

--- a/env.json
+++ b/env.json
@@ -3,18 +3,21 @@
         "BASE_URL": "/",
         "FM_API_SERVER_ADDRESS": "http://localdocker:5000/",
         "FM_SOCKET_ADDRESS": "http://localdocker:8080",
-        "HTML5_LOCATION": true
+        "HTML5_LOCATION": true,
+        "GOOGLE_CLIENT_ID": "826576189197-4sr9fonm8vr6ora4mfgdtou6j3v69asq.apps.googleusercontent.com"
     },
     "production": {
         "BASE_URL": "http://thisissoon.fm/",
         "FM_API_SERVER_ADDRESS": "http://api.thisissoon.fm/",
         "FM_SOCKET_ADDRESS": "http://sockets.thisissoon.fm/",
-        "HTML5_LOCATION": true
+        "HTML5_LOCATION": true,
+        "GOOGLE_CLIENT_ID": "826576189197-4sr9fonm8vr6ora4mfgdtou6j3v69asq.apps.googleusercontent.com"
     },
     "phonegap": {
         "BASE_URL": "./",
         "FM_API_SERVER_ADDRESS": "http://api.thisissoon.fm/",
         "FM_SOCKET_ADDRESS": "http://sockets.thisissoon.fm/",
-        "HTML5_LOCATION": false
+        "HTML5_LOCATION": false,
+        "GOOGLE_CLIENT_ID": "826576189197-4sr9fonm8vr6ora4mfgdtou6j3v69asq.apps.googleusercontent.com"
     }
 }

--- a/scripts.json
+++ b/scripts.json
@@ -7,7 +7,8 @@
         "app/components/angular-material/angular-material.js",
         "app/components/angular-resource/angular-resource.js",
         "app/components/angular-spotify/src/angular-spotify.js",
-        "app/components/angular-socket-io/socket.js"
+        "app/components/angular-socket-io/socket.js",
+        "app/components/satellizer/satellizer.js"
     ],
     "application": [
         "app/js/fm-socket/socket.js",

--- a/tests/unit/fm-api/factories/RequestInterceptor.js
+++ b/tests/unit/fm-api/factories/RequestInterceptor.js
@@ -1,7 +1,7 @@
 "use strict";
 
 describe("sn.fm.api:RequestInterceptor", function (){
-    var interceptor, httpProvider, $location, resource, requestHandler, spy;
+    var interceptor, httpProvider, $location, resource, requestHandler, spy, FM_API_SERVER_ADDRESS;
 
     beforeEach(function (){
         module("sn.fm.api", function ($httpProvider){
@@ -10,6 +10,8 @@ describe("sn.fm.api:RequestInterceptor", function (){
     });
 
     beforeEach(inject(function ( $injector, $resource ){
+
+        FM_API_SERVER_ADDRESS = $injector.get("FM_API_SERVER_ADDRESS");
 
         interceptor = $injector.get("RequestInterceptor");
 
@@ -30,6 +32,26 @@ describe("sn.fm.api:RequestInterceptor", function (){
     it("should NOT redirect to 500 page on response success", function(){
         interceptor.responseError({ status: 200 })
         expect($location.path).not.toHaveBeenCalled();
+    });
+
+    it("should set Access-Token header from local storage", function(){
+        localStorage.setItem("sn_fm_access_token", "mockAccessToken")
+        var httpConfig = {
+            url: FM_API_SERVER_ADDRESS,
+            headers: {}
+        };
+        var request = interceptor.request(httpConfig);
+        expect(request.headers["Access-Token"]).toEqual("mockAccessToken");
+    });
+
+    it("should NOT set Access-Token header if no token saved", function(){
+        localStorage.clear();
+        var httpConfig = {
+            url: FM_API_SERVER_ADDRESS,
+            headers: {}
+        };
+        var request = interceptor.request(httpConfig);
+        expect(request.headers["Access-Token"]).toBe(undefined);
     });
 
 });


### PR DESCRIPTION
This adds auth configuration to `sn-fm-api` and a request interceptor to add the `Access-Token` header to FM API requests with the access token from local storage.

Once the interface for the login button has been finalised, the integration can be completed.