### PR TITLE
Feature: users in queue

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -74,6 +74,7 @@
         <script src="js/fm-api/factories/PlayerTransportResource.js"></script>
         <script src="js/fm-api/factories/PlayerVolumeResource.js"></script>
         <script src="js/fm-api/factories/TracksResource.js"></script>
+        <script src="js/fm-api/factories/UsersResource.js"></script>
         <script src="js/fm-api/factories/RequestInterceptor.js"></script>
 
         <script src="js/fm-player/app.js"></script>

--- a/app/js/fm-api/factories/UsersResource.js
+++ b/app/js/fm-api/factories/UsersResource.js
@@ -1,0 +1,26 @@
+"use strict";
+/**
+ * Factory which provides methods to perform on thisisoon FM API
+ * /users endpoint. Gets user data.
+ * @class UserResource
+ */
+angular.module("sn.fm.api").factory("UsersResource", [
+    "$resource",
+    "FM_API_SERVER_ADDRESS",
+    /**
+     * @constructor
+     * @param {Service} $resource
+     * @param {String}  FM_API_SERVER_ADDRESS
+     */
+    function ($resource, FM_API_SERVER_ADDRESS) {
+
+        return $resource(
+            FM_API_SERVER_ADDRESS + "users" + "/:id",
+            // Default values for url parameters.
+            {
+                id: "@id"
+            }
+        );
+
+    }
+]);

--- a/app/js/fm-player/controllers/PlayerCtrl.js
+++ b/app/js/fm-player/controllers/PlayerCtrl.js
@@ -14,6 +14,7 @@ angular.module("sn.fm.player").controller("PlayerCtrl", [
     "PlayerQueueResource",
     "PlayerTransportResource",
     "TracksResource",
+    "UsersResource",
     "PlayerMuteResource",
     "PlayerVolumeResource",
     "playlistData",
@@ -27,11 +28,12 @@ angular.module("sn.fm.player").controller("PlayerCtrl", [
      * @param {Factory} PlayerQueueResource
      * @param {Factory} PlayerTranportResource
      * @param {Factory} TracksResource
+     * @param {Factory} UsersResource
      * @param {Array}   playlistData
      * @param {Object}  currentTrack
      * @param {Object}  muteState
      */
-    function ($scope, $q, $mdToast, PlayerQueueResource, PlayerTransportResource, TracksResource, PlayerMuteResource, PlayerVolumeResource, playlistData, currentTrack, muteState) {
+    function ($scope, $q, $mdToast, PlayerQueueResource, PlayerTransportResource, TracksResource, UsersResource, PlayerMuteResource, PlayerVolumeResource, playlistData, currentTrack, muteState) {
 
         /**
          * An instance of the $resource PlayerQueueResource
@@ -168,7 +170,7 @@ angular.module("sn.fm.player").controller("PlayerCtrl", [
          * @method init
          */
         $scope.init = function init() {
-            if ($scope.current.id){
+            if ($scope.current.track.id){
                 $scope.playlist.unshift($scope.current);
             }
         };
@@ -179,7 +181,7 @@ angular.module("sn.fm.player").controller("PlayerCtrl", [
          * @method onPlay
          */
         $scope.onPlay = function onPlay(event, data) {
-            if ($scope.playlist[0].uri === data.uri) { // jshint ignore:line
+            if ($scope.playlist[0].track.uri === data.uri) { // jshint ignore:line
                 $scope.paused = false;
                 $scope.current = $scope.playlist[0];
             } else {
@@ -194,7 +196,7 @@ angular.module("sn.fm.player").controller("PlayerCtrl", [
          * @method onEnd
          */
         $scope.onEnd = function onEnd(event, data) {
-            if ($scope.playlist[0].uri === data.uri) { // jshint ignore:line
+            if ($scope.playlist[0].track.uri === data.uri) { // jshint ignore:line
                 $scope.playlist.splice(0, 1);
             } else {
                 $scope.refreshPlaylist();
@@ -222,16 +224,23 @@ angular.module("sn.fm.player").controller("PlayerCtrl", [
          * @method onAdd
          */
         $scope.onAdd = function onAdd(event, data) {
-            TracksResource.get({ id: data.uri }).$promise
-                .then(function (track){
-                    $scope.playlist.push(track);
-                    $mdToast.show(
-                        $mdToast.simple()
-                            .content("Track: " + track.name + " added to playlist")
-                            .position("bottom right")
-                            .hideDelay(5000)
-                        );
-                });
+            $q.all([
+                TracksResource.get({ id: data.uri }).$promise,
+                UsersResource.get({ id: data.user }).$promise
+            ]).then(function(response){
+                var item = {
+                    track: response[0],
+                    user: response[1]
+                };
+                $scope.playlist.push(item);
+
+                $mdToast.show(
+                    $mdToast.simple()
+                        .content(item.user.display_name + " added " + item.track.name + " to the playlist") // jshint ignore:line
+                        .position("bottom right")
+                        .hideDelay(5000)
+                    );
+            });
         };
 
         /**

--- a/app/js/fm-player/controllers/PlayerCtrl.js
+++ b/app/js/fm-player/controllers/PlayerCtrl.js
@@ -170,7 +170,7 @@ angular.module("sn.fm.player").controller("PlayerCtrl", [
          * @method init
          */
         $scope.init = function init() {
-            if ($scope.current.track.id){
+            if ($scope.current.track && $scope.current.track.id){
                 $scope.playlist.unshift($scope.current);
             }
         };

--- a/app/js/fm-player/directives/track.js
+++ b/app/js/fm-player/directives/track.js
@@ -16,7 +16,8 @@ angular.module("sn.fm.player").directive("fmTrack",[
         return {
             restrict: "EA",
             scope: {
-                track: "=spotifyTrack"
+                track: "=spotifyTrack",
+                user: "="
             },
             templateUrl: "partials/track.html"
         };

--- a/app/less/default/core/reset.less
+++ b/app/less/default/core/reset.less
@@ -13,3 +13,7 @@ ng-view {
     padding: 7px;
     overflow: auto;
 }
+
+img {
+    max-width: 100%;
+}

--- a/app/less/default/modules/tracks.less
+++ b/app/less/default/modules/tracks.less
@@ -79,3 +79,12 @@
 .track.playing .album {
     font-size: 1.6em;
 }
+
+.track .avatar {
+    padding-right: 20px;
+    max-width: 80px;
+
+    img {
+        border-radius: 50%;
+    }
+}

--- a/app/less/mobile/modules/tracks.less
+++ b/app/less/mobile/modules/tracks.less
@@ -29,3 +29,7 @@
 .track.playing .artwork {
     width: 110px;
 }
+
+.track .avatar {
+    max-width: 50px;
+}

--- a/app/partials/player.html
+++ b/app/partials/player.html
@@ -25,7 +25,8 @@
         <fm-track
             class="track"
             ng-class="{ playing: $first }"
-            data-spotify-track="track">
+            data-spotify-track="track.track"
+            data-user="track.user">
         </fm-track>
     </md-item>
 </md-list>

--- a/app/partials/track.html
+++ b/app/partials/track.html
@@ -11,8 +11,8 @@
     <div class="md-tile-content"
          layout="row"
          layout-align="space-around center"
-         layout-sm="column"
-         layout-align-sm="space-between center">
+         layout-sm="row"
+         layout-align-sm="space-between start">
 
         <div class="md-tile-content details">
             <h3 class="name">
@@ -30,6 +30,13 @@
 
         <div class="length" hide-sm>
             {{ track.duration | date: "m:ss" }}
+        </div>
+
+        <div class="md-tile-content avatar" ng-if="user">
+            <img ng-src="{{ user.avatar_url }}">
+            <md-tooltip>
+                {{ user.display_name }}
+            </md-tooltip>
         </div>
 
     </div>

--- a/scripts.json
+++ b/scripts.json
@@ -22,6 +22,7 @@
         "app/js/fm-api/factories/PlayerTransportResource.js",
         "app/js/fm-api/factories/PlayerVolumeResource.js",
         "app/js/fm-api/factories/TracksResource.js",
+        "app/js/fm-api/factories/UsersResource.js",
         "app/js/fm-api/factories/RequestInterceptor.js",
 
         "app/js/fm-player/app.js",

--- a/tests/unit/fm-player/controllers/PlayerCtrl.js
+++ b/tests/unit/fm-player/controllers/PlayerCtrl.js
@@ -2,9 +2,9 @@
 
 describe("sn.fm.player:PlayerCtrl", function() {
 
-    var $scope, $q, PlayerMuteResource, PlayerQueueResource, PlayerTransportResource, PlayerVolumeResource, TracksResource,
-        spotifyCallback, queueCallback, trackCallback, volumeCallback, mockPlayerVolumeResource,
-        _volumeInstance, _playlistData, _currentTrack, _muteState;
+    var $scope, $q, PlayerMuteResource, PlayerQueueResource, PlayerTransportResource, PlayerVolumeResource, TracksResource, UsersResource,
+        spotifyCallback, queueCallback, currentCallback, trackCallback, userCallback, volumeCallback, mockPlayerVolumeResource,
+        _volumeInstance, _playlistData, _currentTrack, _track, _user, _muteState;
 
     beforeEach(function (){
         module("sn.fm.player");
@@ -27,11 +27,29 @@ describe("sn.fm.player:PlayerCtrl", function() {
                 }
             }
         }
-        trackCallback = function(){
+        currentCallback = function(){
             return {
                 $promise: {
                     then: function(fn){
                         fn.apply(this,[_currentTrack])
+                    }
+                }
+            }
+        }
+        trackCallback = function(){
+            return {
+                $promise: {
+                    then: function(fn){
+                        fn.apply(this,[_track])
+                    }
+                }
+            }
+        }
+        userCallback = function(){
+            return {
+                $promise: {
+                    then: function(fn){
+                        fn.apply(this,[_user])
                     }
                 }
             }
@@ -53,7 +71,7 @@ describe("sn.fm.player:PlayerCtrl", function() {
         spyOn(PlayerQueueResource, "query").and.callFake(queueCallback);
 
         PlayerTransportResource = $injector.get("PlayerTransportResource");
-        spyOn(PlayerTransportResource, "get").and.callFake(trackCallback);
+        spyOn(PlayerTransportResource, "get").and.callFake(currentCallback);
         spyOn(PlayerTransportResource, "resume");
         spyOn(PlayerTransportResource, "pause");
         spyOn(PlayerTransportResource, "skip");
@@ -65,65 +83,74 @@ describe("sn.fm.player:PlayerCtrl", function() {
         TracksResource = $injector.get("TracksResource");
         spyOn(TracksResource, "get").and.callFake(trackCallback);
 
+        UsersResource = $injector.get("UsersResource");
+        spyOn(UsersResource, "get").and.callFake(userCallback);
+
         _playlistData = [{
-            "album" : {
-                "id" : "4b170737-017c-4e85-965c-47b8a158c785",
-                "images" : [ {
-                    "height" : 640,
-                    "url" : "https://i.scdn.co/image/e1c8594562d35cd8d4338bfeb6c6b23bd41fd942",
-                    "width" : 640
-                }, {
-                    "height" : 300,
-                    "url" : "https://i.scdn.co/image/ca4b85e01309d843d615b8ab93d312742650e46d",
-                    "width" : 300
-                }, {
-                    "height" : 64,
-                    "url" : "https://i.scdn.co/image/e76deee80fb59daef5f531d08e2fc156c9bdff9a",
-                    "width" : 64
+            "track": {
+                "album" : {
+                    "id" : "4b170737-017c-4e85-965c-47b8a158c785",
+                    "images" : [ {
+                        "height" : 640,
+                        "url" : "https://i.scdn.co/image/e1c8594562d35cd8d4338bfeb6c6b23bd41fd942",
+                        "width" : 640
+                    }, {
+                        "height" : 300,
+                        "url" : "https://i.scdn.co/image/ca4b85e01309d843d615b8ab93d312742650e46d",
+                        "width" : 300
+                    }, {
+                        "height" : 64,
+                        "url" : "https://i.scdn.co/image/e76deee80fb59daef5f531d08e2fc156c9bdff9a",
+                        "width" : 64
+                    } ],
+                    "name" : "Brothers (Deluxe Edition)",
+                    "uri" : "spotify:album:0gVxPZ2tcMgyzLxyw8k1z7"
+                },
+                "artists" : [ {
+                    "id" : "4b170737-017c-4e85-965c-47b8a158c787",
+                    "name" : "The Black Keys",
+                    "uri" : "spotify:artist:7mnBLXK823vNxN3UWB7Gfz"
                 } ],
-                "name" : "Brothers (Deluxe Edition)",
-                "uri" : "spotify:album:0gVxPZ2tcMgyzLxyw8k1z7"
+                "duration" : 204626,
+                "id" : "4b170737-017c-4e85-965c-47b8a158c784",
+                "name" : "Everlasting Light",
+                "uri" : "spotify:track:3OYPskZPKnOcHZ9fUDwmCK"
             },
-            "artists" : [ {
-                "id" : "4b170737-017c-4e85-965c-47b8a158c787",
-                "name" : "The Black Keys",
-                "uri" : "spotify:artist:7mnBLXK823vNxN3UWB7Gfz"
-            } ],
-            "duration" : 204626,
-            "id" : "4b170737-017c-4e85-965c-47b8a158c784",
-            "name" : "Everlasting Light",
-            "uri" : "spotify:track:3OYPskZPKnOcHZ9fUDwmCK"
+            "user": _user,
         }, {
-            "album" : {
-                "id" : "4b170737-017c-4e85-965c-47b8a158c786",
-                "images" : [ {
-                    "height" : 640,
-                    "url" : "https://i.scdn.co/image/b26866432cca1c107c3fa6f5fee5c80995d99e75",
-                    "width" : 640
-                }, {
-                    "height" : 300,
-                    "url" : "https://i.scdn.co/image/db5b7075ed0d352dae4d36e5f1af9d1c57d4c046",
-                    "width" : 300
-                }, {
-                    "height" : 64,
-                    "url" : "https://i.scdn.co/image/ccf3a54fae2aa343a4bab5b75279c70f889c6612",
-                    "width" : 64
+            "track": {
+                "album" : {
+                    "id" : "4b170737-017c-4e85-965c-47b8a158c786",
+                    "images" : [ {
+                        "height" : 640,
+                        "url" : "https://i.scdn.co/image/b26866432cca1c107c3fa6f5fee5c80995d99e75",
+                        "width" : 640
+                    }, {
+                        "height" : 300,
+                        "url" : "https://i.scdn.co/image/db5b7075ed0d352dae4d36e5f1af9d1c57d4c046",
+                        "width" : 300
+                    }, {
+                        "height" : 64,
+                        "url" : "https://i.scdn.co/image/ccf3a54fae2aa343a4bab5b75279c70f889c6612",
+                        "width" : 64
+                    } ],
+                    "name" : "Lonely Boy",
+                    "sptofy_uri" : "spotify:album:2uGi7bQZU5My0k1UGJQRz2"
+                },
+                "artists" : [ {
+                    "id" : "4b170737-017c-4e85-965c-47b8a158c787",
+                    "name" : "The Black Keys",
+                    "uri" : "spotify:artist:7mnBLXK823vNxN3UWB7Gfz"
                 } ],
+                "duration" : 193173,
+                "id" : "4b170737-017c-4e85-965c-47b8a158c788",
                 "name" : "Lonely Boy",
-                "sptofy_uri" : "spotify:album:2uGi7bQZU5My0k1UGJQRz2"
+                "uri" : "spotify:track:3dOAXUx7I1qnzWzxdnsyB8"
             },
-            "artists" : [ {
-                "id" : "4b170737-017c-4e85-965c-47b8a158c787",
-                "name" : "The Black Keys",
-                "uri" : "spotify:artist:7mnBLXK823vNxN3UWB7Gfz"
-            } ],
-            "duration" : 193173,
-            "id" : "4b170737-017c-4e85-965c-47b8a158c788",
-            "name" : "Lonely Boy",
-            "uri" : "spotify:track:3dOAXUx7I1qnzWzxdnsyB8"
+            "user": _user,
         }]
 
-        _currentTrack = {
+        _track = {
             "album": {
                 "artists": [
                     {
@@ -156,7 +183,20 @@ describe("sn.fm.player:PlayerCtrl", function() {
             "duration": 272906,
             "id": "4b170737-017c-4e85-965c-47b8a158c789",
             "name": "Dark Chest Of Wonders - Live @ Wacken 2013",
-            "uri": "spotify:track:6FshvOVICpRVkwpYE5BYTD",
+            "uri": "spotify:track:6FshvOVICpRVkwpYE5BYTD"
+        }
+
+        _user = {
+            "avatar_url": "https://lh5.googleusercontent.com/-8zjhd-e4yZA/AAAAAAAAAAI/AAAAAAAAAFU/NiS1oH4gAKo/photo.jpg",
+            "display_name": "Chris Reeves",
+            "family_name": "Reeves",
+            "given_name": "Chris",
+            "id": "8258be6b-ee53-4186-8bbd-55bc0a3a6f24"
+        }
+
+        _currentTrack = {
+            "track": _track,
+            "user": _user,
             "paused": 0
         }
 
@@ -296,7 +336,7 @@ describe("sn.fm.player:PlayerCtrl", function() {
     describe("socket event handling", function(){
 
         it("should update playlist on end event", function() {
-            var eventData = { uri: _currentTrack.uri },
+            var eventData = { uri: _currentTrack.track.uri },
                 expectLength = $scope.playlist.length - 1;
 
             $scope.$broadcast("fm:player:end", eventData);
@@ -314,13 +354,13 @@ describe("sn.fm.player:PlayerCtrl", function() {
         });
 
         it("should update playlist and current on play event", function() {
-            var eventData = { uri: _playlistData[0].uri };
+            var eventData = { uri: _playlistData[0].track.uri };
 
             $scope.$broadcast("fm:player:play", eventData);
 
             expect($scope.paused).toEqual(false);
             expect($scope.current).toEqual($scope.playlist[0]);
-            expect($scope.current.uri).toEqual(eventData.uri);
+            expect($scope.current.track.uri).toEqual(eventData.uri);
         });
 
         it("should call refreshPlaylist on play event if track doesn't match playlist", function() {
@@ -343,11 +383,16 @@ describe("sn.fm.player:PlayerCtrl", function() {
         });
 
         it("should add track to playlist on add event", function() {
-            var eventData = { uri: "spotify:track:3OYPskZPKnOcHZ9fUDwmCK" };
+            var eventData = { uri: _track.uri, user: _user.id },
+                expectedLength = $scope.playlist.length + 1;
 
             $scope.$broadcast("fm:player:add", eventData);
-            expect($scope.playlist.length).toEqual(4);
-            expect($scope.playlist[3]).toEqual(_currentTrack);
+            $scope.$apply();
+
+            expect(TracksResource.get).toHaveBeenCalledWith({ id: _track.uri });
+            expect(UsersResource.get).toHaveBeenCalledWith({ id: _user.id });
+            expect($scope.playlist.length).toEqual(expectedLength);
+            expect($scope.playlist[3]).toEqual({ track: _track, user: _user });
         });
 
         it("should set mute state on setMute event", function() {


### PR DESCRIPTION
This implements https://github.com/thisissoon/FM-API/pull/13 https://github.com/thisissoon/FM-API/issues/12, adding user avatars to tracks in the queue. This is just positioned on the right of the track at block the moment. Perhaps a temporary position until the designs are finalised.

