### PR TITLE
Feature: inview error handling

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -79,6 +79,7 @@
 
         <script src="js/fm-player/app.js"></script>
         <script src="js/fm-player/config.js"></script>
+        <script src="js/fm-player/constants/errors.js"></script>
         <script src="js/fm-player/controllers/LoginCtrl.js"></script>
         <script src="js/fm-player/controllers/PlayerCtrl.js"></script>
         <script src="js/fm-player/controllers/SearchCtrl.js"></script>

--- a/app/js/fm-api/factories/RequestInterceptor.js
+++ b/app/js/fm-api/factories/RequestInterceptor.js
@@ -16,6 +16,8 @@ angular.module("sn.fm.api").factory("RequestInterceptor", [
      */
     function ($q, $location, config, FM_API_SERVER_ADDRESS) {
 
+        var tokenName = config.tokenPrefix ? config.tokenPrefix + "_" + config.tokenName : config.tokenName;
+
         return {
 
             /**
@@ -24,8 +26,6 @@ angular.module("sn.fm.api").factory("RequestInterceptor", [
              * @returns {Object} modified httpConfig
              */
             request: function(httpConfig) {
-
-                var tokenName = config.tokenPrefix ? config.tokenPrefix + "_" + config.tokenName : config.tokenName;
 
                 if(httpConfig.url.match(FM_API_SERVER_ADDRESS)) {
 
@@ -47,11 +47,18 @@ angular.module("sn.fm.api").factory("RequestInterceptor", [
              */
             responseError: function(response) {
 
+                // Clear auth token if FM API returns "Unauthorised" status code
+                if (response.config.url.match(FM_API_SERVER_ADDRESS) && response.status === 401) {
+                    localStorage.removeItem(tokenName);
+                }
+
                 if (response.status === 401){
                     $location.path("/401");
                 } else if (response.status < 200 || response.status > 299){
                     $location.path("/500");
                 }
+
+                return response;
 
             }
         };

--- a/app/js/fm-api/factories/RequestInterceptor.js
+++ b/app/js/fm-api/factories/RequestInterceptor.js
@@ -3,18 +3,20 @@
  * @class RequestInterceptor
  */
 angular.module("sn.fm.api").factory("RequestInterceptor", [
+    "$rootScope",
     "$q",
     "$location",
     "satellizer.config",
     "FM_API_SERVER_ADDRESS",
     /**
      * @constructor
+     * @param {Service} $rootScope
      * @param {Service} $q
      * @param {Service} $location
-     * @param {Object}  config                   satellizer configuration
-     * @param {String}  FM_API_SERVER_ADDRESS    API server url
+     * @param {Object}  config                satellizer configuration
+     * @param {String}  FM_API_SERVER_ADDRESS API server url
      */
-    function ($q, $location, config, FM_API_SERVER_ADDRESS) {
+    function ($rootScope, $q, $location, config, FM_API_SERVER_ADDRESS) {
 
         var tokenName = config.tokenPrefix ? config.tokenPrefix + "_" + config.tokenName : config.tokenName;
 
@@ -52,10 +54,13 @@ angular.module("sn.fm.api").factory("RequestInterceptor", [
                     localStorage.removeItem(tokenName);
                 }
 
-                if (response.status === 401){
-                    $location.path("/401");
-                } else if (response.status < 200 || response.status > 299){
-                    $location.path("/500");
+                // Navigate to error pages if server returns error code whilst FE route is changing
+                if($rootScope.routeChanging){
+                    if (response.status === 401){
+                        $location.path("/401");
+                    } else if (response.status < 200 || response.status > 299){
+                        $location.path("/500");
+                    }
                 }
 
                 return response;

--- a/app/js/fm-player/app.js
+++ b/app/js/fm-player/app.js
@@ -54,5 +54,15 @@ angular.module("sn.fm.player", ["ENV", "ngRoute", "ngMaterial", "spotify", "sate
             return Boolean($auth.getToken());
         };
 
+        $rootScope.$on("$routeChangeStart", function(){
+            $rootScope.routeChanging = true;
+        });
+        $rootScope.$on("$routeChangeSuccess", function(){
+            $rootScope.routeChanging = false;
+        });
+        $rootScope.$on("$routeChangeError", function(){
+            $rootScope.routeChanging = false;
+        });
+
     }
 ]);

--- a/app/js/fm-player/constants/errors.js
+++ b/app/js/fm-player/constants/errors.js
@@ -1,0 +1,10 @@
+"use strict";
+angular.module("sn.fm.player")
+
+    .constant("ERRORS", {
+        "AUTH_VALIDATION_TITLE": "Sorry guys...",
+        "AUTH_VALIDATION_MESSAGE": "You need to be a member of SOON_ or This Here.",
+        "UNKNOWN_TITLE": "Something strange happened...",
+        "STATUS_401_TITLE": "Unauthorised",
+        "STATUS_401_MESSAGE": "You need to be logged in to do that."
+    });

--- a/app/js/fm-player/controllers/LoginCtrl.js
+++ b/app/js/fm-player/controllers/LoginCtrl.js
@@ -9,13 +9,14 @@ angular.module("sn.fm.player").controller("LoginCtrl", [
     "$scope",
     "$route",
     "$auth",
+    "$mdDialog",
     /**
      * @constructor
      * @param {Object}   $scope
      * @param {Service}  $route
      * @param {Service}  $auth  satellizer $auth service
      */
-    function ($scope, $route, $auth) {
+    function ($scope, $route, $auth, $mdDialog) {
 
         /**
          * Authenticate with google oauth
@@ -23,14 +24,36 @@ angular.module("sn.fm.player").controller("LoginCtrl", [
          */
         $scope.authenticate = function() {
 
-            $auth.authenticate("google").then(function(response) {
-                if (response.data.access_token) { // jshint ignore:line
+            $auth.authenticate("google")
+                .then(function(response) {
                     $route.reload();
-                } else {
-                    $auth.removeToken();
-                }
-            });
+                })
+                .catch(function(error){
+                    // Satellizer returns an error if there is no token, parse the error to get the original API response
+                    var response = JSON.parse(error.message.match(/\{.*\}/));
 
+                    if (response.message === "Validation Error") {
+                        $scope.showAlert("Sorry guys...", response.errors.code[0]);
+                    }
+
+                    $auth.removeToken();
+                });
+
+        };
+
+        /**
+         * Show alert dialog with mdDialog service
+         * @param {String} title   title to display in dialog
+         * @param {String} content content to display in dialog
+         */
+        $scope.showAlert = function showAlert(title, content) {
+            $mdDialog.show(
+                $mdDialog.alert()
+                    .title(title)
+                    .content(content)
+                    .ariaLabel("Alert")
+                    .ok("Ok")
+            );
         };
 
     }

--- a/app/js/fm-player/controllers/LoginCtrl.js
+++ b/app/js/fm-player/controllers/LoginCtrl.js
@@ -10,13 +10,16 @@ angular.module("sn.fm.player").controller("LoginCtrl", [
     "$route",
     "$auth",
     "$mdDialog",
+    "ERRORS",
     /**
      * @constructor
-     * @param {Object}   $scope
-     * @param {Service}  $route
-     * @param {Service}  $auth  satellizer $auth service
+     * @param {Object}  $scope
+     * @param {Service} $route
+     * @param {Service} $auth     satellizer $auth service
+     * @param {Service} $mdDialog angular material dialog service
+     * @param {Object}  ERRORS    error message copy
      */
-    function ($scope, $route, $auth, $mdDialog) {
+    function ($scope, $route, $auth, $mdDialog, ERRORS) {
 
         /**
          * Authenticate with google oauth
@@ -25,15 +28,15 @@ angular.module("sn.fm.player").controller("LoginCtrl", [
         $scope.authenticate = function() {
 
             $auth.authenticate("google")
-                .then(function(response) {
+                .then(function() {
                     $route.reload();
                 })
                 .catch(function(error){
                     // Satellizer returns an error if there is no token, parse the error to get the original API response
                     var response = JSON.parse(error.message.match(/\{.*\}/));
 
-                    if (response.message === "Validation Error") {
-                        $scope.showAlert("Sorry guys...", response.errors.code[0]);
+                    if (response && response.message === "Validation Error") {
+                        $scope.showAlert(ERRORS.AUTH_VALIDATION_TITLE, response.errors.code[0]);
                     }
 
                     $auth.removeToken();

--- a/app/js/fm-player/controllers/PlayerCtrl.js
+++ b/app/js/fm-player/controllers/PlayerCtrl.js
@@ -79,7 +79,19 @@ angular.module("sn.fm.player").controller("PlayerCtrl", [
          */
         $scope.resume = function resume() {
             $scope.paused = false;
-            PlayerTransportResource.resume();
+
+            PlayerTransportResource.resume().$promise
+                .then(function(response){
+                    // Check if resume was successfully set, if not revert local state
+                    if (!response.message.match("200")) {
+                        $scope.paused = true;
+                    }
+
+                    // Handle unauthorised response status in-view
+                    if (response.message.match("401")) {
+                        $scope.showAlert(ERRORS.STATUS_401_TITLE, ERRORS.STATUS_401_MESSAGE);
+                    }
+                });
         };
 
         /**
@@ -88,7 +100,19 @@ angular.module("sn.fm.player").controller("PlayerCtrl", [
          */
         $scope.pause = function pause() {
             $scope.paused = true;
-            PlayerTransportResource.pause({});
+
+            PlayerTransportResource.pause({}).$promise
+                .then(function(response){
+                    // Check if pause was successfully set, if not revert local state
+                    if (!response.message.match("200")) {
+                        $scope.mute = false;
+                    }
+
+                    // Handle unauthorised response status in-view
+                    if (response.message.match("401")) {
+                        $scope.showAlert(ERRORS.STATUS_401_TITLE, ERRORS.STATUS_401_MESSAGE);
+                    }
+                });
         };
 
         /**
@@ -96,7 +120,13 @@ angular.module("sn.fm.player").controller("PlayerCtrl", [
          * @method skip
          */
         $scope.skip = function skip() {
-            PlayerTransportResource.skip();
+            PlayerTransportResource.skip().$promise
+                .then(function(response){
+                    // Handle unauthorised response status in-view
+                    if (response.message.match("401")) {
+                        $scope.showAlert(ERRORS.STATUS_401_TITLE, ERRORS.STATUS_401_MESSAGE);
+                    }
+                });
         };
 
         /**
@@ -151,6 +181,7 @@ angular.module("sn.fm.player").controller("PlayerCtrl", [
          */
         $scope.toggleMute = function toggleMute() {
             if ($scope.mute) {
+                // un-mute
                 $scope.mute = false;
 
                 PlayerMuteResource.delete().$promise
@@ -166,6 +197,7 @@ angular.module("sn.fm.player").controller("PlayerCtrl", [
                         }
                     });
             } else {
+                // mute
                 $scope.mute = true;
 
                 PlayerMuteResource.save({ mute: true }).$promise

--- a/scripts.json
+++ b/scripts.json
@@ -27,6 +27,7 @@
 
         "app/js/fm-player/app.js",
         "app/js/fm-player/config.js",
+        "app/js/fm-player/constants/errors.js",
         "app/js/fm-player/controllers/LoginCtrl.js",
         "app/js/fm-player/controllers/PlayerCtrl.js",
         "app/js/fm-player/controllers/SearchCtrl.js",

--- a/tests/unit/fm-api/factories/RequestInterceptor.js
+++ b/tests/unit/fm-api/factories/RequestInterceptor.js
@@ -1,7 +1,7 @@
 "use strict";
 
 describe("sn.fm.api:RequestInterceptor", function (){
-    var interceptor, httpProvider, $location, resource, requestHandler, spy, FM_API_SERVER_ADDRESS;
+    var interceptor, httpProvider, $location, rootScope, resource, requestHandler, spy, FM_API_SERVER_ADDRESS;
 
     beforeEach(function (){
         module("sn.fm.api", function ($httpProvider){
@@ -9,7 +9,10 @@ describe("sn.fm.api:RequestInterceptor", function (){
         });
     });
 
-    beforeEach(inject(function ( $injector, $resource ){
+    beforeEach(inject(function ( $rootScope, $injector, $resource ){
+
+        $rootScope.routeChanging = true;
+        rootScope = $rootScope;
 
         FM_API_SERVER_ADDRESS = $injector.get("FM_API_SERVER_ADDRESS");
 
@@ -25,18 +28,24 @@ describe("sn.fm.api:RequestInterceptor", function (){
     });
 
     it("should redirect to 500 page on response error", function(){
-        interceptor.responseError({ status: 500 })
+        interceptor.responseError({ status: 500, config: { url: FM_API_SERVER_ADDRESS } })
         expect($location.path).toHaveBeenCalledWith("/500");
     });
 
     it("should NOT redirect to 500 page on response success", function(){
-        interceptor.responseError({ status: 200 })
+        interceptor.responseError({ status: 200, config: { url: FM_API_SERVER_ADDRESS } })
         expect($location.path).not.toHaveBeenCalled();
     });
 
     it("should redirect to 401 page on 401 response status", function(){
-        interceptor.responseError({ status: 401 })
+        interceptor.responseError({ status: 401, config: { url: FM_API_SERVER_ADDRESS } })
         expect($location.path).toHaveBeenCalledWith("/401");
+    });
+
+    it("should NOT redirect to error pages if route is not changing", function(){
+        rootScope.routeChanging = false;
+        interceptor.responseError({ status: 401, config: { url: FM_API_SERVER_ADDRESS } })
+        expect($location.path).not.toHaveBeenCalled();
     });
 
     it("should set Access-Token header from local storage", function(){

--- a/tests/unit/fm-player/app.js
+++ b/tests/unit/fm-player/app.js
@@ -27,4 +27,22 @@ describe("sn.fm.player:app", function() {
         var sidenav = $rootScope.openSideNav("foo");
         expect(sidenav).toEqual(jasmine.any(Object));
     })
+
+    it("should set routeChanging state true on start", function() {
+        $rootScope.routeChanging = false;
+        $rootScope.$broadcast("$routeChangeStart");
+        expect($rootScope.routeChanging).toEqual(true);
+    })
+
+    it("should set routeChanging state false on success", function() {
+        $rootScope.routeChanging = true;
+        $rootScope.$broadcast("$routeChangeSuccess");
+        expect($rootScope.routeChanging).toEqual(false);
+    })
+
+    it("should set routeChanging state false on error", function() {
+        $rootScope.routeChanging = true;
+        $rootScope.$broadcast("$routeChangeError");
+        expect($rootScope.routeChanging).toEqual(false);
+    })
 });

--- a/tests/unit/fm-player/controllers/LoginCtrl.js
+++ b/tests/unit/fm-player/controllers/LoginCtrl.js
@@ -2,7 +2,7 @@
 
 describe("sn.fm.player:LoginCtrl", function() {
 
-    var $scope, _route, _auth, _mockTokenResponse;
+    var $scope, _route, _auth, _mdDialog, _mockTokenResponse, _mockAuthError, ERRORS;
 
     beforeEach(function (){
         module("sn.fm.player");
@@ -18,22 +18,36 @@ describe("sn.fm.player:LoginCtrl", function() {
 
         _auth = $injector.get("$auth");
         _auth.authenticate = function(provider){
-            return {
+            var $promise = {
                 then: function(fn){
                     fn.apply(this, [_mockTokenResponse]);
+                    return $promise;
+                },
+                catch: function(fn){
+                    fn.apply(this, [_mockAuthError]);
+                    return $promise;
                 }
             };
+
+            return $promise;
         };
         _auth.removeToken = function(){};
         spyOn(_auth, "authenticate").and.callThrough();
         spyOn(_auth, "removeToken");
 
+        _mdDialog = $injector.get("$mdDialog");
+
+        _mockAuthError = { message: "Expecting a token named \"access_token\" but instead got: {\"message\":\"Validation Error\",\"errors\":{\"code\":[\"You need be a member of SOON_ or This Here\"]}}" };
         _mockTokenResponse = { data: { access_token: "mocktoken" }};
+
+        ERRORS = $injector.get("ERRORS");
 
         $controller("LoginCtrl", {
             $scope: $scope,
             $auth: _auth,
-            $route: _route
+            $route: _route,
+            $mdDialog: _mdDialog,
+            ERRORS: ERRORS
         });
     }));
 
@@ -46,6 +60,23 @@ describe("sn.fm.player:LoginCtrl", function() {
     it("should call remove token if no token is returned in auth", function() {
         _mockTokenResponse.data.access_token = undefined;
         $scope.authenticate();
+        expect(_auth.removeToken).toHaveBeenCalled();
+    });
+
+    it("should show authentication validation error alert", function() {
+        spyOn($scope, "showAlert");
+
+        $scope.authenticate();
+        expect($scope.showAlert).toHaveBeenCalledWith(ERRORS.AUTH_VALIDATION_TITLE, "You need be a member of SOON_ or This Here");
+        expect(_auth.removeToken).toHaveBeenCalled();
+    });
+
+    it("should NOT show authentication validation error alert", function() {
+        spyOn($scope, "showAlert");
+        _mockAuthError = { message: "" };
+
+        $scope.authenticate();
+        expect($scope.showAlert).not.toHaveBeenCalled();
         expect(_auth.removeToken).toHaveBeenCalled();
     });
 


### PR DESCRIPTION
This is a proof of concept for handling in-view errors vs error on page-load.

Errors on page-load should trigger the relevant error page. In-view errors should be handled within their respective controller and trigger a dialog. 

At the moment I have only implemented this on the `toggleMute` action as a proof of concept for early review. Also the `authenticate` action will catch an error if user is not a member of SOON_ of This Here and display a dialog.

No tests yet. Needs more work before merge.