### PR TITLE
Fix: adjust autocomplete ul positioning

### DIFF
--- a/app/less/default/modules/spotify-search.less
+++ b/app/less/default/modules/spotify-search.less
@@ -15,8 +15,9 @@
 }
 
 .spotify-search ul {
-    margin-bottom: 20px;
-    max-height: none;
+    margin: 60px 10px 20px 10px;
+    max-height: ~"calc(100% - 80px)";
+    top: 0;
 }
 
 .spotify-search ul li {
@@ -37,4 +38,8 @@
 
 .spotify-search .track .length {
     display: none;
+}
+
+md-autocomplete {
+    position: static;
 }


### PR DESCRIPTION
This fixes #51 by re-positioning the `md-autocomplete` element to use the scrollbar of the dropdown rather than the sidebar.