### PR TITLE
Fix: volume slider

### DIFF
--- a/app/js/player/controllers/PlayerCtrl.js
+++ b/app/js/player/controllers/PlayerCtrl.js
@@ -103,7 +103,7 @@ angular.module("FM.player.PlayerCtrl",[
          * @method skip
          */
         $scope.updateVol = function updateVol() {
-            PlayerVolumeResource.save({ volume: $scope.volume });
+            PlayerVolumeResource.save({ volume: parseInt($scope.volume) });
         };
 
         /**

--- a/tests/unit/player/controllers/PlayerCtrl.js
+++ b/tests/unit/player/controllers/PlayerCtrl.js
@@ -92,7 +92,7 @@ describe("FM.player.PlayerCtrl", function() {
     });
 
     it("should make request to update volume", function(){
-        $scope.volume = 70;
+        $scope.volume = "70";
         $scope.updateVol();
         $httpBackend.flush();
         expect(PlayerVolumeResource.save).toHaveBeenCalledWith({ volume: 70 });


### PR DESCRIPTION
`<input type="range">` bizarrely works with strings so we need to parse this as an integer before posting to the API. Fixes #57 