### PR TITLE
Feature: slider fill

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -88,6 +88,7 @@
 
         <script src="js/player/player.js"></script>
         <script src="js/player/controllers/PlayerCtrl.js"></script>
+        <script src="js/player/directives/slider.js"></script>
         <script src="js/player/directives/track.js"></script>
 
         <script src="js/playlist/playlist.js"></script>

--- a/app/js/player/directives/slider.js
+++ b/app/js/player/directives/slider.js
@@ -1,0 +1,50 @@
+"use strict";
+/**
+ * @module FM.player.sliderDirective
+ * @author SOON_
+ */
+angular.module("FM.player.sliderDirective", [
+
+])
+/**
+ * @example
+ *  <fm-slider
+ *      ng-model="model"
+ *      ng-change="update()"
+ *      data-min="0"
+ *      data-max="100">
+ *  </fm-slider>
+ * @constructor
+ * @class fmSlider
+ */
+.directive("fmSlider",[
+    function (){
+        return {
+            restrict: "EA",
+            require: "ngModel",
+            scope: {
+                min: "@",
+                max: "@"
+            },
+            templateUrl: "partials/slider.html",
+            link:  function($scope, $element, $attrs, ngModel) {
+
+                /**
+                 * Update ngModel.$viewValue with new slider value onChange
+                 * @method onChange
+                 */
+                $scope.onChange = function onChange(){
+                    ngModel.$setViewValue($scope.sliderValue);
+                };
+
+                /**
+                 * Update slider value on ngModel change
+                 */
+                ngModel.$render = function () {
+                    $scope.sliderValue = ngModel.$viewValue;
+                };
+
+            }
+        };
+    }
+]);

--- a/app/js/player/player.js
+++ b/app/js/player/player.js
@@ -10,5 +10,6 @@
  */
 angular.module("FM.player", [
     "FM.player.PlayerCtrl",
-    "FM.player.trackDirective"
+    "FM.player.trackDirective",
+    "FM.player.sliderDirective"
 ]);

--- a/app/less/default/core/variables.less
+++ b/app/less/default/core/variables.less
@@ -120,11 +120,12 @@
 
 // input[type="range"] properties
 @track-color:                   transparent;
-@thumb-color:                   @gray-light;
+@track-fill:                    @gray-light;
+@thumb-color:                   @white;
 
 @thumb-radius:                  8px;
-@thumb-height:                  8px;
-@thumb-width:                   24px;
+@thumb-height:                  12px;
+@thumb-width:                   12px;
 @thumb-border-width:            0px;
 @thumb-border-color:            transparent;
 

--- a/app/less/default/core/variables.less
+++ b/app/less/default/core/variables.less
@@ -123,7 +123,7 @@
 @thumb-color:                   @gray-light;
 
 @thumb-radius:                  8px;
-@thumb-height:                  12px;
+@thumb-height:                  8px;
 @thumb-width:                   24px;
 @thumb-border-width:            0px;
 @thumb-border-color:            transparent;

--- a/app/less/default/modules/controls.less
+++ b/app/less/default/modules/controls.less
@@ -21,9 +21,28 @@
     min-width: 40px;
 }
 
-input[type=range].volume-control {
-    line-height: 30px;
+.volume-control {
     margin: 0 10px;
     vertical-align: middle;
     width: 129px;
+}
+
+fm-slider {
+    display: inline-block;
+    height: max(@thumb-height, @track-height);
+    position: relative;
+
+    input[type="range"],
+    .slider-fill {
+        display: block;
+        margin: 0;
+        position: absolute;
+    }
+
+    .slider-fill {
+        background-color: @gray-light;
+        border-radius: @track-radius;
+        height: @track-height;
+        min-width: @track-radius * 2;
+    }
 }

--- a/app/less/default/modules/controls.less
+++ b/app/less/default/modules/controls.less
@@ -40,7 +40,7 @@ fm-slider {
     }
 
     .slider-fill {
-        background-color: @gray-light;
+        background-color: @track-fill;
         border-radius: @track-radius;
         height: @track-height;
         min-width: @track-radius * 2;

--- a/app/partials/footer.html
+++ b/app/partials/footer.html
@@ -28,19 +28,20 @@
                 <span ng-switch-default class="icon icon-unmuted"></span>
             </button>
 
-            <input class="volume-control"
-                   ng-model="volume"
-                   ng-model-options="{
-                       updateOn: 'default blur',
-                       debounce: {
-                           'default': 500,
-                           'blur': 0
-                       }
-                   }"
-                   ng-change="updateVol()"
-                   type="range"
-                   min="0"
-                   max="100">
+            <fm-slider
+                class="volume-control"
+                ng-model="volume"
+                ng-change="updateVol()"
+                ng-model-options="{
+                    updateOn: 'default blur',
+                    debounce: {
+                        'default': 500,
+                        'blur': 0
+                    }
+                }"
+                data-min="0"
+                data-max="100">
+            </fm-slider>
 
         </form>
 

--- a/app/partials/slider.html
+++ b/app/partials/slider.html
@@ -1,0 +1,7 @@
+<div class="slider-fill" ng-style="{'width': sliderValue + '%' }"></div>
+<input  ng-model="sliderValue"
+        ng-change="onChange()"
+        ng-model-options="{}"
+        type="range"
+        min="{{min}}"
+        max="{{max}}">

--- a/scripts.json
+++ b/scripts.json
@@ -36,6 +36,7 @@
         "app/js/player/player.js",
         "app/js/player/controllers/PlayerCtrl.js",
         "app/js/player/directives/track.js",
+        "app/js/player/directives/slider.js",
 
         "app/js/playlist/playlist.js",
         "app/js/playlist/controllers/PlaylistCtrl.js",

--- a/tests/unit/player/directives/slider.js
+++ b/tests/unit/player/directives/slider.js
@@ -1,0 +1,40 @@
+"use strict";
+
+describe("FM.player.sliderDirective", function() {
+    var element, $scope, $rootScope, $templateCache, isolateScope;
+
+    beforeEach(module("FM.player.sliderDirective"));
+
+    beforeEach(inject(function (_$rootScope_, $compile, $injector) {
+        $rootScope = _$rootScope_;
+
+        $scope = $rootScope.$new();
+        $scope.model = 1;
+
+        element = "<fm-slider ng-model=\"model\" data-min=\"0\" data-max=\"100\"></fm-slider>";
+
+        $templateCache = $injector.get("$templateCache");
+        $templateCache.put("partials/slider.html", "foo");
+
+        element = $compile(element)($scope);
+        $scope.$digest();
+
+        isolateScope = element.isolateScope();
+
+    }));
+
+    it("should render directive", function(){
+        expect(element.html()).toContain("foo");
+    });
+
+    it("should set sliderValue to ngModel", function(){
+        expect(isolateScope.sliderValue).toEqual(1);
+    });
+
+    it("should set ngModel onChange", function(){
+        isolateScope.sliderValue = 5;
+        isolateScope.onChange();
+        expect($scope.model).toEqual(5);
+    });
+
+});


### PR DESCRIPTION
fmSlider directive to add fill to volume slider #73.

![screenshot 2015-06-01 18 45 34](https://cloud.githubusercontent.com/assets/1857944/7919198/8cd0305e-088e-11e5-8868-5486cdfe2dfc.png)

The directive makes use of ngModel so we can continue to use the built-in debounce features. For example:
```
<fm-slider
    class="volume-control"
    ng-model="volume"
    ng-change="updateVol()"
    ng-model-options="{
        updateOn: 'default blur',
        debounce: {
            'default': 500,
            'blur': 0
        }
    }"
    data-min="0"
    data-max="100">
</fm-slider>
```