### PR TITLE
Feature: fix pagination meta

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -89,6 +89,7 @@
         <script src="js/api/factories/TracksResource.js"></script>
         <script src="js/api/factories/UsersResource.js"></script>
         <script src="js/api/factories/RequestInterceptor.js"></script>
+        <script src="js/api/factories/PaginationInterceptor.js"></script>
 
         <script src="js/history/history.js"></script>
         <script src="js/history/controllers/HistoryCtrl.js"></script>

--- a/app/js/api/api.js
+++ b/app/js/api/api.js
@@ -14,6 +14,7 @@ angular.module("FM.api", [
     "FM.api.TracksResource",
     "FM.api.UsersResource",
     "FM.api.RequestInterceptor",
+    "FM.api.PaginationInterceptor",
     "FM.api.ERRORS"
 ])
 /**

--- a/app/js/api/api.js
+++ b/app/js/api/api.js
@@ -14,7 +14,6 @@ angular.module("FM.api", [
     "FM.api.TracksResource",
     "FM.api.UsersResource",
     "FM.api.RequestInterceptor",
-    "FM.api.PaginationInterceptor",
     "FM.api.ERRORS"
 ])
 /**

--- a/app/js/api/factories/PaginationInterceptor.js
+++ b/app/js/api/factories/PaginationInterceptor.js
@@ -33,13 +33,17 @@ angular.module("FM.api.PaginationInterceptor", [
              */
             response: function(response){
 
-                if(response.config.isArray || response.data.length ) {
-                    response.data.meta = {
-                        totalPages: parseInt(response.headers("Total-Pages")),
-                        totalCount: parseInt(response.headers("Total-Count"))
+                var newResponse = response;
+                if(response.data && angular.isArray(response.data)) {
+                    newResponse.data = {
+                        items: response.data,
+                        meta: {
+                            totalPages: parseInt(response.headers("Total-Pages")),
+                            totalCount: parseInt(response.headers("Total-Count"))
+                        }
                     };
                 }
-                return response;
+                return newResponse;
             }
         };
 

--- a/app/js/api/factories/PaginationInterceptor.js
+++ b/app/js/api/factories/PaginationInterceptor.js
@@ -1,0 +1,47 @@
+"use strict";
+/**
+ * @module FM.api.PaginationInterceptor
+ * @author SOON_
+ */
+angular.module("FM.api.PaginationInterceptor", [
+
+])
+/**
+ * @method config
+ * @param  {Provider} $httpProvider
+ */
+.config([
+    "$httpProvider",
+    function ($httpProvider) {
+
+        $httpProvider.interceptors.push("PaginationInterceptor");
+
+    }
+])
+/**
+ * @constructor
+ * @class PaginationInterceptor
+ */
+.factory("PaginationInterceptor", [
+    function () {
+
+        return {
+            /**
+             * Adds pagination meta data to response body for paginated resources
+             * @param   {Object} response $http response
+             * @returns {Object} response with added metadata
+             */
+            response: function(response){
+
+                if(response.config.isArray || response.data.length ) {
+                    response.data.meta = {
+                        totalPages: parseInt(response.headers("Total-Pages")),
+                        totalCount: parseInt(response.headers("Total-Count"))
+                    };
+                }
+                return response;
+            }
+        };
+
+    }
+]);

--- a/app/js/api/factories/PlayerHistoryResource.js
+++ b/app/js/api/factories/PlayerHistoryResource.js
@@ -7,6 +7,7 @@
  */
 angular.module("FM.api.PlayerHistoryResource", [
     "ENV",
+    "FM.api.PaginationInterceptor",
     "ngResource"
 ])
 /**
@@ -20,7 +21,15 @@ angular.module("FM.api.PlayerHistoryResource", [
     "FM_API_SERVER_ADDRESS",
     function ($resource, FM_API_SERVER_ADDRESS) {
 
-        return $resource(FM_API_SERVER_ADDRESS + "player/history");
+        return $resource(
+            FM_API_SERVER_ADDRESS + "player/history",
+            {},
+            {
+                query: {
+                    isArray: false
+                }
+            }
+        );
 
     }
 ]);

--- a/app/js/api/factories/PlayerHistoryResource.js
+++ b/app/js/api/factories/PlayerHistoryResource.js
@@ -20,24 +20,7 @@ angular.module("FM.api.PlayerHistoryResource", [
     "FM_API_SERVER_ADDRESS",
     function ($resource, FM_API_SERVER_ADDRESS) {
 
-        return $resource(
-            FM_API_SERVER_ADDRESS + "player/history",
-            // Default values for url parameters.
-            {},
-            // Hash with declaration of custom action that should
-            // extend the default set of resource actions
-            {
-                query: {
-                    method: "GET",
-                    isArray: true,
-                    transformResponse: function (data, headers){
-                        var transformedResponse = angular.fromJson(data);
-                        transformedResponse.totalPages = parseInt(headers("Total-Pages"));
-                        return transformedResponse;
-                    }
-                }
-            }
-        );
+        return $resource(FM_API_SERVER_ADDRESS + "player/history");
 
     }
 ]);

--- a/app/js/history/controllers/HistoryCtrl.js
+++ b/app/js/history/controllers/HistoryCtrl.js
@@ -56,7 +56,7 @@ angular.module("FM.history.HistoryCtrl", [
         $scope.page = {
             loading: false,
             pages: 1,
-            total: historyData.totalPages
+            total: historyData.meta.totalPages
         };
 
         /**
@@ -68,12 +68,12 @@ angular.module("FM.history.HistoryCtrl", [
             $scope.page.loading = true;
             $scope.page.pages++;
 
-            PlayerHistoryResource.query({ page: $scope.page.pages },
-                function(response){
+            PlayerHistoryResource.query({ page: $scope.page.pages }).$promise
+                .then(function(response){
                     $scope.history = $scope.history.concat(response);
 
                     $scope.page.loading = false;
-                    $scope.page.total = response.totalPages || 0;
+                    $scope.page.total = response.meta.totalPages || 0;
                 });
         };
 

--- a/app/js/history/controllers/HistoryCtrl.js
+++ b/app/js/history/controllers/HistoryCtrl.js
@@ -47,7 +47,7 @@ angular.module("FM.history.HistoryCtrl", [
          * @property history
          * @type {Array}
          */
-        $scope.history = historyData;
+        $scope.history = historyData.items;
 
         /**
          * Paging properties
@@ -70,7 +70,7 @@ angular.module("FM.history.HistoryCtrl", [
 
             PlayerHistoryResource.query({ page: $scope.page.pages }).$promise
                 .then(function(response){
-                    $scope.history = $scope.history.concat(response);
+                    $scope.history = $scope.history.concat(response.items);
 
                     $scope.page.loading = false;
                     $scope.page.total = response.meta.totalPages || 0;

--- a/scripts.json
+++ b/scripts.json
@@ -36,6 +36,7 @@
         "app/js/api/factories/TracksResource.js",
         "app/js/api/factories/UsersResource.js",
         "app/js/api/factories/RequestInterceptor.js",
+        "app/js/api/factories/PaginationInterceptor.js",
 
         "app/js/history/history.js",
         "app/js/history/controllers/HistoryCtrl.js",

--- a/tests/unit/api/factories/PaginationInterceptor.js
+++ b/tests/unit/api/factories/PaginationInterceptor.js
@@ -1,0 +1,32 @@
+"use strict";
+
+describe("FM.api.PaginationInterceptor", function (){
+    var interceptor, httpProvider, rootScope;
+
+    beforeEach(function (){
+        module("FM.api.PaginationInterceptor", function ($httpProvider){
+            httpProvider = $httpProvider;
+        });
+    });
+
+    beforeEach(inject(function ( $rootScope, $injector ){
+
+        rootScope = $rootScope;
+
+        interceptor = $injector.get("PaginationInterceptor");
+        spyOn(interceptor, "response").and.callThrough();
+
+    }));
+
+    it("$http service should contain response interceptor", function(){
+        expect(httpProvider.interceptors).toContain("PaginationInterceptor");
+    });
+
+    it("should add pagination meta to response data", function(){
+        var response = interceptor.response({ status: 200, config: {}, data: [{ name: "some name" }], headers: function(){ return "10" } })
+        expect(response.data.meta.totalPages).toEqual(10);
+        expect(response.data.meta.totalCount).toEqual(10);
+    });
+
+});
+

--- a/tests/unit/history/controllers/HistoryCtrl.js
+++ b/tests/unit/history/controllers/HistoryCtrl.js
@@ -12,7 +12,7 @@ describe("FM.history.HistoryCtrl", function() {
      beforeEach(inject(function (_$httpBackend_) {
         $httpBackend = _$httpBackend_
 
-        $httpBackend.whenGET(/.*player\/history/).respond(200, [{ track: { uri: "foo" } },{ track: { uri: "bar" } }]);
+        $httpBackend.whenGET(/.*player\/history/).respond(200, [{ track: { uri: "foo" } },{ track: { uri: "bar" } }], { "Total-Pages": "10", "Total-Count": "10" });
         $httpBackend.whenGET(/partials\/.*/).respond(200);
     }));
 
@@ -27,7 +27,8 @@ describe("FM.history.HistoryCtrl", function() {
         PlayerHistoryResource = $injector.get("PlayerHistoryResource");
         spyOn(PlayerHistoryResource, "query").and.callThrough();
 
-        historyData = [{ track: { uri: "foo" } },{ track: { uri: "bar" } }];
+        historyData = { items: [{ track: { uri: "foo" } },{ track: { uri: "bar" } }] };
+        historyData.meta = { totalPages: 10, totalCount: 10 }
 
         $controller("HistoryCtrl", {
             $scope: $scope,
@@ -49,7 +50,7 @@ describe("FM.history.HistoryCtrl", function() {
     });
 
     it("should attach data to $scope", function(){
-        expect($scope.history).toEqual(historyData);
+        expect($scope.history).toEqual(historyData.items);
     });
 
     it("should query next page from PlayerHistoryResource and add data to scope", function(){
@@ -59,6 +60,7 @@ describe("FM.history.HistoryCtrl", function() {
         $httpBackend.flush();
         expect($scope.page.loading).toBe(false);
         expect($scope.history.length).toEqual(4);
+        expect($scope.page.total).toEqual(10);
     });
 
 });


### PR DESCRIPTION
Originally I wanted to attach the meta data as a property of the resource, something like `[ 0: {}, 1:{}, meta:{} ]` however this seems to get stripped by angular so an alternative solution could be to transform paginated resources to the following format `{ items: [], meta: { totalPages: 10, totalCount: 100 }}` as implemented below with an $httpInterceptor.

Let me know your thoughts or if you think there could be a better solution...