### PR TITLE
Fix: track timer

### DIFF
--- a/app/js/player/controllers/PlayerCtrl.js
+++ b/app/js/player/controllers/PlayerCtrl.js
@@ -77,7 +77,7 @@ angular.module("FM.player.PlayerCtrl",[
                 if ($scope.track && $scope.track.track) {
 
                     // Start track position timer
-                    var elapsed = parseInt(response[0].elapsed_time) || 0; // jshint ignore:line
+                    var elapsed = parseInt(response[0].player.elapsed_time) || 0; // jshint ignore:line
                     $scope.trackPositionTimer.start($scope.track.track.duration, elapsed);
 
                     $notification("Now Playing", {

--- a/app/js/player/controllers/PlayerCtrl.js
+++ b/app/js/player/controllers/PlayerCtrl.js
@@ -142,6 +142,8 @@ angular.module("FM.player.PlayerCtrl",[
          * @method onEnd
          */
         $scope.onEnd = function onEnd() {
+            $scope.trackPositionTimer.stop();
+            $scope.trackPositionTimer.reset();
             $scope.track = null;
         };
 

--- a/tests/unit/player/controllers/PlayerCtrl.js
+++ b/tests/unit/player/controllers/PlayerCtrl.js
@@ -16,7 +16,7 @@ describe("FM.player.PlayerCtrl", function() {
         $httpBackend.whenDELETE(/.*player\/mute/).respond(200, { message: "200 OK" });
         $httpBackend.whenPOST(/.*player\/mute/).respond(200, { message: "200 OK" });
 
-        $httpBackend.whenGET(/.*player\/current/).respond(200, {"track": {"album": {"id": "d7b737a9-d70b-49a9-9f42-8c204b342000", "images": [{"url": "http://placehold.it/640x629?text=Album+Art", "width": 640, "height": 629}, {"url": "http://placehold.it/300x295?text=Album+Art", "width": 300, "height": 295}, {"url": "http://placehold.it/64x63?text=Album+Art", "width": 64, "height": 63}], "name": "Boston", "uri": "spotify:album:2QLp07RO6anZHmtcKTEvSC"}, "name": "More Than a Feeling", "uri": "spotify:track:1QEEqeFIZktqIpPI4jSVSF", "play_count": 0, "artists": [{"id": "8c22640a-02ef-4ee0-90eb-87c9c9a2534f", "uri": "spotify:artist:29kkCKKGXheHuoO829FxWK", "name": "Boston"}], "duration": 285133, "id": "0739b113-ad3a-47a4-bea9-edb00ba192f5"}, "user": {"family_name": "Light", "display_name": "Alex Light", "avatar_url": "http://placehold.it/400", "spotify_playlists": null, "given_name": "Alex", "id": "16369f65-6aa5-4d04-8927-a77016d0d721"}}, { "Paused": 1 });
+        $httpBackend.whenGET(/.*player\/current/).respond(200, {"player": { "elapsed_time": 10 }, "track": {"album": {"id": "d7b737a9-d70b-49a9-9f42-8c204b342000", "images": [{"url": "http://placehold.it/640x629?text=Album+Art", "width": 640, "height": 629}, {"url": "http://placehold.it/300x295?text=Album+Art", "width": 300, "height": 295}, {"url": "http://placehold.it/64x63?text=Album+Art", "width": 64, "height": 63}], "name": "Boston", "uri": "spotify:album:2QLp07RO6anZHmtcKTEvSC"}, "name": "More Than a Feeling", "uri": "spotify:track:1QEEqeFIZktqIpPI4jSVSF", "play_count": 0, "artists": [{"id": "8c22640a-02ef-4ee0-90eb-87c9c9a2534f", "uri": "spotify:artist:29kkCKKGXheHuoO829FxWK", "name": "Boston"}], "duration": 285133, "id": "0739b113-ad3a-47a4-bea9-edb00ba192f5"}, "user": {"family_name": "Light", "display_name": "Alex Light", "avatar_url": "http://placehold.it/400", "spotify_playlists": null, "given_name": "Alex", "id": "16369f65-6aa5-4d04-8927-a77016d0d721"}}, { "Paused": 1 });
         $httpBackend.whenDELETE(/.*player\/current/).respond(200, { message: "200 OK" });
         $httpBackend.whenPOST(/.*player\/pause/).respond(200, { message: "200 OK" });
         $httpBackend.whenDELETE(/.*player\/pause/).respond(200, { message: "200 OK" });
@@ -47,6 +47,7 @@ describe("FM.player.PlayerCtrl", function() {
 
         TrackTimer = $injector.get("TrackTimer");
         spyOn(TrackTimer, "stop").and.callThrough();
+        spyOn(TrackTimer, "start").and.callThrough();
 
         $controller("PlayerCtrl", {
             $scope: $scope,
@@ -78,13 +79,12 @@ describe("FM.player.PlayerCtrl", function() {
         expect($notification).toHaveBeenCalledWith("Now Playing", { body: "Boston - Boston: More Than a Feeling", icon: "http://placehold.it/640x629?text=Album+Art" });
     });
 
-    it("should start timer", function(){
-        spyOn($scope.trackPositionTimer, "start");
+    it("should start timer with elapsed time", function(){
         $scope.getAllData();
         $scope.$apply();
 
         $httpBackend.flush();
-        expect($scope.trackPositionTimer.start).toHaveBeenCalledWith(285133, 0);
+        expect(TrackTimer.start).toHaveBeenCalledWith(285133, 10);
     });
 
     it("should make request to resume playback", function(){
@@ -134,6 +134,12 @@ describe("FM.player.PlayerCtrl", function() {
     it("should set paused state `false` on resume event", function() {
         $scope.$broadcast("fm:player:resume");
         expect($scope.paused).toEqual(false);
+    });
+
+    it("should resume timer on resume event", function() {
+        TrackTimer.start.calls.reset();
+        $scope.$broadcast("fm:player:resume");
+        expect(TrackTimer.start).toHaveBeenCalledWith(285133);
     });
 
     it("should set mute state on setMute event", function() {

--- a/tests/unit/player/controllers/PlayerCtrl.js
+++ b/tests/unit/player/controllers/PlayerCtrl.js
@@ -48,6 +48,7 @@ describe("FM.player.PlayerCtrl", function() {
         TrackTimer = $injector.get("TrackTimer");
         spyOn(TrackTimer, "stop").and.callThrough();
         spyOn(TrackTimer, "start").and.callThrough();
+        spyOn(TrackTimer, "reset").and.callThrough();
 
         $controller("PlayerCtrl", {
             $scope: $scope,
@@ -160,6 +161,12 @@ describe("FM.player.PlayerCtrl", function() {
         expect($scope.track).not.toBeNull();
         $scope.$broadcast("fm:player:end");
         expect($scope.track).toBeNull();
+    });
+
+    it("should stop and reset timer on end event", function() {
+        $scope.$broadcast("fm:player:end");
+        expect(TrackTimer.stop).toHaveBeenCalled();
+        expect(TrackTimer.reset).toHaveBeenCalled();
     });
 
     it("should set mute status to true", function() {

--- a/tests/unit/player/services/TrackTimer.js
+++ b/tests/unit/player/services/TrackTimer.js
@@ -39,6 +39,23 @@ describe("FM.player.TrackTimer", function() {
             expect(TrackTimer.percent).toEqual(20);
         });
 
+        it("should pause and resume timer", function(){
+            jasmine.clock().tick(2000);
+            $interval.flush(2000);
+
+            TrackTimer.stop();
+            TrackTimer.start(5000);
+
+            expect(TrackTimer.elapsedTime).toEqual(2000);
+            expect(TrackTimer.percent).toEqual(40);
+
+            jasmine.clock().tick(1000);
+            $interval.flush(1000);
+
+            expect(TrackTimer.elapsedTime).toEqual(3000);
+            expect(TrackTimer.percent).toEqual(60);
+        });
+
         it("should stop timer when duration is reached", function(){
             spyOn(TrackTimer, "stop");
             jasmine.clock().tick(5000);


### PR DESCRIPTION
This PR includes:

- use correct elapsed time property from API `player.elapsed_time`
- stop and reset timer on end event
- more unit tests