### PR TITLE
Fix: track timer reset bug

### DIFF
--- a/app/js/player/controllers/PlayerCtrl.js
+++ b/app/js/player/controllers/PlayerCtrl.js
@@ -145,7 +145,7 @@ angular.module("FM.player.PlayerCtrl",[
          * @method onEnd
          */
         $scope.onEnd = function onEnd() {
-            $scope.trackPositionTimer.stop();
+            $scope.trackPositionTimer.pause();
             $scope.trackPositionTimer.reset();
             $scope.track = null;
         };
@@ -155,7 +155,7 @@ angular.module("FM.player.PlayerCtrl",[
          * @method onPause
          */
         $scope.onPause = function onPause() {
-            $scope.trackPositionTimer.stop();
+            $scope.trackPositionTimer.pause();
             $scope.paused = true;
         };
 
@@ -210,7 +210,7 @@ angular.module("FM.player.PlayerCtrl",[
 
         $scope.getAllData();
 
-        $scope.$on("$destroy", $scope.trackPositionTimer.stop);
+        $scope.$on("$destroy", $scope.trackPositionTimer.pause);
     }
 
 ]);

--- a/app/js/player/services/TrackTimer.js
+++ b/app/js/player/services/TrackTimer.js
@@ -72,12 +72,6 @@ angular.module("FM.player.TrackTimer", [
          */
         this.start = function start (duration, elapsed) {
 
-            // Clear any existing timer
-            if (startTime) {
-                _this.stop();
-                _this.reset();
-            }
-
             // Default elapsed time on start to 0
             elapsed = elapsed ? elapsed : 0;
 
@@ -121,6 +115,12 @@ angular.module("FM.player.TrackTimer", [
          * @public
          */
         this.reset = function reset () {
+            // Clear running timer
+            if (startTime) {
+                _this.pause();
+            }
+
+            // Reset timer to zero
             startTime = 0;
             lastStopTime = 0;
             _this.elapsedTime = 0;

--- a/app/js/player/services/TrackTimer.js
+++ b/app/js/player/services/TrackTimer.js
@@ -6,7 +6,13 @@
 angular.module("FM.player.TrackTimer", [
 
 ])
-
+/**
+ * Timer service to track elapsed time of currently playing track
+ * @example
+ *  TrackTimer.start(duration, existingElapsedTime) // to start the timer
+ *  TrackTimer.pause() // to pause the timer
+ *  TrackTimer.reset() // to reset the timer to 0
+ */
 .service("TrackTimer", [
     "$interval",
     function ($interval) {
@@ -78,10 +84,11 @@ angular.module("FM.player.TrackTimer", [
             // Set start time
             startTime = now() - elapsed;
 
+            // Store timer as $interval instance
             _this.timerInstance = $interval(function(){
                 // Stop timer when duration is exceeded
                 if (_this.elapsedTime >= duration) {
-                    _this.stop();
+                    _this.pause();
                     return;
                 }
 
@@ -93,12 +100,12 @@ angular.module("FM.player.TrackTimer", [
         };
 
         /**
-         * Stop timer and clear timer instance
-         * @method stop
+         * Pause timer and clear timer instance
+         * @method pause
          * @public
          */
-        this.stop = function stop () {
-            // If running, update elapsed time otherwise keep it
+        this.pause = function pause () {
+            // If timer is running, update elapsed time otherwise keep it
             lastStopTime = startTime ? lastStopTime + now() - startTime : lastStopTime;
             startTime = 0;
 

--- a/tests/unit/player/controllers/PlayerCtrl.js
+++ b/tests/unit/player/controllers/PlayerCtrl.js
@@ -46,7 +46,7 @@ describe("FM.player.PlayerCtrl", function() {
         spyOn(PlayerVolumeResource, "save").and.callThrough();
 
         TrackTimer = $injector.get("TrackTimer");
-        spyOn(TrackTimer, "stop").and.callThrough();
+        spyOn(TrackTimer, "pause").and.callThrough();
         spyOn(TrackTimer, "start").and.callThrough();
         spyOn(TrackTimer, "reset").and.callThrough();
 
@@ -163,9 +163,9 @@ describe("FM.player.PlayerCtrl", function() {
         expect($scope.track).toBeNull();
     });
 
-    it("should stop and reset timer on end event", function() {
+    it("should pause and reset timer on end event", function() {
         $scope.$broadcast("fm:player:end");
-        expect(TrackTimer.stop).toHaveBeenCalled();
+        expect(TrackTimer.pause).toHaveBeenCalled();
         expect(TrackTimer.reset).toHaveBeenCalled();
     });
 
@@ -179,9 +179,9 @@ describe("FM.player.PlayerCtrl", function() {
         expect($scope.mute).toBe(false);
     });
 
-    it("should stop timer on destroy", function() {
+    it("should pause timer on destroy", function() {
         $scope.$broadcast("$destroy");
-        expect(TrackTimer.stop).toHaveBeenCalled();
+        expect(TrackTimer.pause).toHaveBeenCalled();
     });
 
 });

--- a/tests/unit/player/services/TrackTimer.js
+++ b/tests/unit/player/services/TrackTimer.js
@@ -72,32 +72,12 @@ describe("FM.player.TrackTimer", function() {
         });
 
         it("should reset timer", function(){
+            spyOn(TrackTimer, "pause");
             TrackTimer.reset();
+
             expect(TrackTimer.elapsedTime).toEqual(0);
             expect(TrackTimer.percent).toEqual(0);
-        });
-
-        it("should restart timer if called twice", function(){
-            // 1st timer
-            spyOn(TrackTimer, "stop");
-            spyOn(TrackTimer, "reset");
-            jasmine.clock().tick(4000);
-            $interval.flush(4000);
-            expect(TrackTimer.elapsedTime).toEqual(4000);
-
-            // start again
-            TrackTimer.start(5000);
-
-            // stop and reset timer
-            expect(TrackTimer.stop).toHaveBeenCalled();
-            expect(TrackTimer.reset).toHaveBeenCalled();
-
-            // 2nd timer
-            jasmine.clock().tick(1000);
-            $interval.flush(1000);
-
-            expect(TrackTimer.elapsedTime).toEqual(1000);
-            expect(TrackTimer.percent).toEqual(20);
+            expect(TrackTimer.pause).toHaveBeenCalled();
         });
 
     });

--- a/tests/unit/player/services/TrackTimer.js
+++ b/tests/unit/player/services/TrackTimer.js
@@ -27,7 +27,7 @@ describe("FM.player.TrackTimer", function() {
         });
 
         afterEach(function () {
-            TrackTimer.stop();
+            TrackTimer.pause();
         });
 
         it("should start timer and update elapsedTime", function(){
@@ -43,7 +43,7 @@ describe("FM.player.TrackTimer", function() {
             jasmine.clock().tick(2000);
             $interval.flush(2000);
 
-            TrackTimer.stop();
+            TrackTimer.pause();
             TrackTimer.start(5000);
 
             expect(TrackTimer.elapsedTime).toEqual(2000);
@@ -56,17 +56,17 @@ describe("FM.player.TrackTimer", function() {
             expect(TrackTimer.percent).toEqual(60);
         });
 
-        it("should stop timer when duration is reached", function(){
-            spyOn(TrackTimer, "stop");
+        it("should pause timer when duration is reached", function(){
+            spyOn(TrackTimer, "pause");
             jasmine.clock().tick(5000);
             $interval.flush(5000);
 
-            expect(TrackTimer.stop).toHaveBeenCalled();
+            expect(TrackTimer.pause).toHaveBeenCalled();
         });
 
-        it("should cancel timer", function(){
+        it("should cancel $interval instance", function(){
             $interval.flush(1000);
-            TrackTimer.stop();
+            TrackTimer.pause();
 
             expect($interval.cancel).toHaveBeenCalledWith(TrackTimer.timerInstance);
         });
@@ -110,7 +110,7 @@ describe("FM.player.TrackTimer", function() {
         });
 
         afterEach(function () {
-            TrackTimer.stop();
+            TrackTimer.pause();
         });
 
         it("should offset elapsed time", function(){


### PR DESCRIPTION
The timer was setup to reset when calling `TrackTimer.start(..)` with a timer running. When the events are running and a user clicks resume `$scope.onResume` is called twice; once when the resume action is completed by the API and once on the resume socket event (thus this issue only affects the user who clicks the resume button as they are the only one to get the double call). As the issue is introduced only when the events are active it was not caught in our unit or e2e tests.

This PR:
 - Stops the timer resetting on multiple calls to `.start()`, now the timer has to be explicitly reset with `.reset()`
 - Renames the `stop` method to `pause` as that makes more sense
 - Fixes #99 