### PR TITLE
Fix: Hide progress bar and controls if no current tracks

### DIFF
--- a/app/js/player/controllers/PlayerCtrl.js
+++ b/app/js/player/controllers/PlayerCtrl.js
@@ -38,7 +38,7 @@ angular.module("FM.player.PlayerCtrl",[
          * @property track
          * @type     {Object}
          */
-        $scope.track = {};
+        $scope.track = null;
 
         /**
          * Tracks the state of mute

--- a/app/partials/footer.html
+++ b/app/partials/footer.html
@@ -1,5 +1,5 @@
 <div ng-controller="PlayerCtrl">
-    <fm-track class="media" data-spotify-track="track.track" data-user="track.user" data-timer="trackPositionTimer"></fm-track>
+    <fm-track class="media" ng-show="track" data-spotify-track="track.track" data-user="track.user" data-timer="trackPositionTimer"></fm-track>
 
     <div class="controls" ng-show="track">
 


### PR DESCRIPTION
Fixed a bug where if a user logged into the player and there wasn't a track currently playing it would still display the controls and progress bar.