### PR TITLE
Fix: Progress bar size

### DIFF
--- a/app/less/default/modules/track.less
+++ b/app/less/default/modules/track.less
@@ -59,7 +59,7 @@
     .flex-grow(1);
     .align-self(center);
     margin-right: 20px;
-    width: 400px;
+    min-width: 400px;
 }
 
 .track-body {
@@ -115,7 +115,7 @@
 
 .track-time {
     .align-self(flex-end);
-    min-width: 40px;
+    min-width: 100px;
 
     .footer & {
         .align-self(center);


### PR DESCRIPTION
Stop the progress bar and timer changing length and being squashed when the track name/album/artist is long.