### PR TITLE
Fix: Hide controls if no tracks

### DIFF
--- a/app/partials/footer.html
+++ b/app/partials/footer.html
@@ -1,7 +1,7 @@
 <div ng-controller="PlayerCtrl">
-    <fm-track class="track" ng-show="track" data-spotify-track="track.track" data-user="track.user" data-timer="trackPositionTimer"></fm-track>
+    <fm-track class="track" ng-show="track.track.uri" data-spotify-track="track.track" data-user="track.user" data-timer="trackPositionTimer"></fm-track>
 
-    <div class="controls" ng-show="track">
+    <div class="controls" ng-show="track.track.uri">
 
         <div class="playing-animation"
              ng-switch="paused">


### PR DESCRIPTION
So track was being defined from api even when there was no track as an empty object. So changed the check to look for a property inside the object