### PR TITLE
Fix: total play time stat

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -137,6 +137,7 @@
 
     <script src="js/stats/stats.js"></script>
     <script src="js/stats/controllers/StatsCtrl.js"></script>
+    <script src="js/stats/filters/time.js"></script>
 
     <script src="js/app.js"></script>
     <!-- /build -->

--- a/app/js/stats/filters/time.js
+++ b/app/js/stats/filters/time.js
@@ -1,0 +1,57 @@
+"use strict";
+/**
+ * @module   FM.stats.timeFilter
+ * @author   SOON_
+ */
+angular.module("FM.stats.timeFilter", [
+
+])
+/**
+ * Split time in milliseconds into separate components;
+ * minutes, hours, days
+ */
+.filter("time", [
+    function(){
+        return function(input){
+
+            /**
+             * Time split into its component
+             * @property {Object} time
+             */
+            var time = {};
+
+            /**
+             * Time remaining
+             * @property remainingTime
+             */
+            var remainingTime = input / 1000;
+
+            time.seconds = Math.round(remainingTime % 60);
+
+            remainingTime /= 60;
+            time.minutes = Math.round(remainingTime % 60);
+
+            remainingTime /= 60;
+            time.hours = Math.round(remainingTime % 24);
+
+            remainingTime /= 24;
+            time.days = Math.round(remainingTime);
+
+            var output = time.minutes + "m";
+
+            if (time.hours || time.days) {
+                output = time.hours + "h " + output;
+            }
+            if (time.days) {
+                var descriptor = "day";
+                if (time.days > 1) {
+                    descriptor = descriptor + "s";
+                }
+
+                output = time.days + descriptor + " " + output;
+            }
+
+            return output;
+        };
+    }
+]);

--- a/app/js/stats/stats.js
+++ b/app/js/stats/stats.js
@@ -4,7 +4,8 @@
  * @author   SOON_
  */
 angular.module("FM.stats", [
-    "FM.stats.StatsCtrl"
+    "FM.stats.StatsCtrl",
+    "FM.stats.timeFilter"
 ])
 /**
  * Colour scheme for charts

--- a/app/partials/stats.html
+++ b/app/partials/stats.html
@@ -32,7 +32,7 @@
                 <p class="text-center">Total Tracks Played</p>
             </div>
             <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12">
-                <h2 class="h1 text-center"><span ng-if="stats.total_play_time > 86400000">{{ stats.total_play_time | date: "M 'month' d 'days'" }}<br></span>{{ stats.total_play_time | date: "H'h' mm'm'" }}</h2>
+                <h2 class="h1 text-center">{{ stats.total_play_time | time }}</h2>
                 <p class="text-center">Total Play Time</p>
             </div>
         </div>

--- a/scripts.json
+++ b/scripts.json
@@ -67,6 +67,7 @@
 
         "./app/js/stats/stats.js",
         "./app/js/stats/controllers/StatsCtrl.js",
+        "./app/js/stats/filters/time.js",
 
         "./app/js/nav/nav.js",
 

--- a/tests/unit/stats/filters/time.js
+++ b/tests/unit/stats/filters/time.js
@@ -1,0 +1,31 @@
+"use strict";
+
+describe("FM.stats.timeFilter", function() {
+    var $scope, filter;
+
+    beforeEach(module("FM.stats.timeFilter"));
+
+    beforeEach(inject(function ($rootScope, $filter, $injector) {
+        $scope = $rootScope.$new();
+        filter = $filter("time");
+
+    }));
+
+    it("should filter times", function(){
+        var result = filter("60000");
+        expect(result).toEqual("1m");
+
+        var result = filter("3600000");
+        expect(result).toEqual("1h 0m");
+
+        var result = filter("3660000");
+        expect(result).toEqual("1h 1m");
+
+        var result = filter("86400000");
+        expect(result).toEqual("1day 0h 0m");
+
+        var result = filter("172800000");
+        expect(result).toEqual("2days 0h 0m");
+    });
+
+});


### PR DESCRIPTION
This PR adds a filter to split the total play time from milliseconds into mins, hours and days. The default angular date filter is optimised for date values and will try to work out the date from the milliseconds, instead it needs to be treated as an elapsed time. Fixes #157 