### PR TITLE
Fix: stat filtering

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -138,6 +138,7 @@
     <script src="js/stats/stats.js"></script>
     <script src="js/stats/controllers/StatsCtrl.js"></script>
     <script src="js/stats/filters/time.js"></script>
+    <script src="js/stats/services/DateUtils.js"></script>
 
     <script src="js/app.js"></script>
     <!-- /build -->

--- a/app/index.html
+++ b/app/index.html
@@ -139,6 +139,7 @@
     <script src="js/stats/controllers/StatsCtrl.js"></script>
     <script src="js/stats/filters/time.js"></script>
     <script src="js/stats/services/DateUtils.js"></script>
+    <script src="js/stats/services/StatsResolver.js"></script>
 
     <script src="js/app.js"></script>
     <!-- /build -->

--- a/app/js/stats/controllers/StatsCtrl.js
+++ b/app/js/stats/controllers/StatsCtrl.js
@@ -5,7 +5,7 @@
  */
 angular.module("FM.stats.StatsCtrl", [
     "FM.stats.DateUtils",
-    "FM.stats.StatsResolver",
+    "FM.stats.statsResolver",
     "FM.api.StatsResource",
     "ngRoute",
     "chart.js",
@@ -24,7 +24,9 @@ angular.module("FM.stats.StatsCtrl", [
                 templateUrl: "partials/stats.html",
                 controller: "StatsCtrl",
                 resolve: {
-                    stats: "StatsResolver"
+                    stats: ["statsResolver", "$route", function (statsResolver, $route) {
+                        return statsResolver($route.current.params);
+                    }]
                 }
             });
 

--- a/app/js/stats/controllers/StatsCtrl.js
+++ b/app/js/stats/controllers/StatsCtrl.js
@@ -5,54 +5,11 @@
  */
 angular.module("FM.stats.StatsCtrl", [
     "FM.stats.DateUtils",
+    "FM.stats.StatsResolver",
     "FM.api.StatsResource",
     "ngRoute",
     "chart.js",
     "ui.bootstrap.datepicker"
-])
-/**
- * Factory to resolve statistics data, with parameter restrictions
- * @param   {Object}   $route
- * @param   {Service}  $filter
- * @param   {String}   $location
- * @param   {Resource} StatsResource Resource to provide communication with API
- * @param   {Service}  DateUtils     Date helper utilities
- * @returns {Promise}  Data resolved from API
- */
-.factory("statsResolver", [
-    "$route",
-    "$filter",
-    "$location",
-    "StatsResource",
-    "DateUtils",
-    function ($route, $filter, $location, StatsResource, DateUtils) {
-
-        /**
-         * New route parameters
-         * @property {Object} params
-         */
-        var params = $route.current.params;
-
-        /**
-         * Is the param `to` greater than last Friday
-         * @property {Boolean} toInvalid
-         */
-        var toInvalid = new Date(params.to) > DateUtils.lastOccurence(5);
-
-        // Restrict `to` search param to last Friday
-        if (!params.to || toInvalid) {
-            params.to = $filter("date")(DateUtils.lastOccurence(5), "yyyy-MM-dd");
-        }
-
-        // Set `from` default to last week
-        if (!params.from && !params.all) {
-            var defaultFrom = new Date().setDate(DateUtils.lastOccurence(5).getDate() - 7);
-            params.from = $filter("date")(defaultFrom, "yyyy-MM-dd");
-        }
-
-        $location.replace().search(params);
-        return StatsResource.get(params).$promise;
-    }
 ])
 /**
  * @method config
@@ -67,7 +24,7 @@ angular.module("FM.stats.StatsCtrl", [
                 templateUrl: "partials/stats.html",
                 controller: "StatsCtrl",
                 resolve: {
-                    stats: "statsResolver"
+                    stats: "StatsResolver"
                 }
             });
 

--- a/app/js/stats/controllers/StatsCtrl.js
+++ b/app/js/stats/controllers/StatsCtrl.js
@@ -4,10 +4,55 @@
  * @author   "SOON_"
  */
 angular.module("FM.stats.StatsCtrl", [
+    "FM.stats.DateUtils",
     "FM.api.StatsResource",
     "ngRoute",
     "chart.js",
     "ui.bootstrap.datepicker"
+])
+/**
+ * Factory to resolve statistics data, with parameter restrictions
+ * @param   {Object}   $route
+ * @param   {Service}  $filter
+ * @param   {String}   $location
+ * @param   {Resource} StatsResource Resource to provide communication with API
+ * @param   {Service}  DateUtils     Date helper utilities
+ * @returns {Promise}  Data resolved from API
+ */
+.factory("statsResolver", [
+    "$route",
+    "$filter",
+    "$location",
+    "StatsResource",
+    "DateUtils",
+    function ($route, $filter, $location, StatsResource, DateUtils) {
+
+        /**
+         * New route parameters
+         * @property {Object} params
+         */
+        var params = $route.current.params;
+
+        /**
+         * Is the param `to` greater than last Friday
+         * @property {Boolean} toInvalid
+         */
+        var toInvalid = new Date(params.to) > DateUtils.lastOccurence(5);
+
+        // Restrict `to` search param to last Friday
+        if (!params.to || toInvalid) {
+            params.to = $filter("date")(DateUtils.lastOccurence(5), "yyyy-MM-dd");
+        }
+
+        // Set `from` default to last week
+        if (!params.from && !params.all) {
+            var defaultFrom = new Date().setDate(DateUtils.lastOccurence(5).getDate() - 7);
+            params.from = $filter("date")(defaultFrom, "yyyy-MM-dd");
+        }
+
+        $location.replace().search(params);
+        return StatsResource.get(params).$promise;
+    }
 ])
 /**
  * @method config
@@ -22,9 +67,7 @@ angular.module("FM.stats.StatsCtrl", [
                 templateUrl: "partials/stats.html",
                 controller: "StatsCtrl",
                 resolve: {
-                    stats: ["StatsResource", "$route", function (StatsResource, $route){
-                        return StatsResource.get($route.current.params).$promise;
-                    }]
+                    stats: "statsResolver"
                 }
             });
 
@@ -42,9 +85,10 @@ angular.module("FM.stats.StatsCtrl", [
     "$location",
     "CHART_COLOURS",
     "CHART_OPTIONS",
+    "DateUtils",
     "StatsResource",
     "stats",
-    function ($scope, $q, $filter, $location, CHART_COLOURS, CHART_OPTIONS, StatsResource, stats) {
+    function ($scope, $q, $filter, $location, CHART_COLOURS, CHART_OPTIONS, DateUtils, StatsResource, stats) {
 
         /**
          * Current search params
@@ -140,7 +184,7 @@ angular.module("FM.stats.StatsCtrl", [
         $scope.loadHistoricData = function loadHistoricData (startDate, endDate) {
 
             startDate = new Date(startDate);
-            endDate = new Date(endDate);
+            endDate = endDate ? new Date(endDate) : new Date();
 
             /**
              * Difference in days between filter start and end dates
@@ -182,9 +226,17 @@ angular.module("FM.stats.StatsCtrl", [
          * @method updateFilter
          */
         $scope.updateFilter = function updateFilter () {
-            $scope.search = $scope.filter;
-            $scope.search.to = $scope.search.to.toISOString ? $filter("date")($scope.search.to.toISOString(), "yyyy-MM-dd") : $scope.search.to;
-            $scope.search.from = $scope.search.from.toISOString ? $filter("date")($scope.search.from.toISOString(), "yyyy-MM-dd") : $scope.search.from;
+            if ($scope.filter.to) {
+                $scope.search.to = $scope.filter.to.toISOString ? $filter("date")($scope.filter.to.toISOString(), "yyyy-MM-dd") : $scope.filter.to;
+            } else {
+                $scope.search.to = undefined;
+            }
+            if ($scope.filter.from) {
+                $scope.search.from = $scope.filter.from.toISOString ? $filter("date")($scope.filter.from.toISOString(), "yyyy-MM-dd") : $scope.filter.from;
+            } else {
+                $scope.search.from = undefined;
+                $scope.search.all = true;
+            }
             $location.search($scope.search);
         };
 
@@ -204,21 +256,11 @@ angular.module("FM.stats.StatsCtrl", [
          */
         $scope.init = function init () {
 
-            /**
-             * Calculate date boundaries of last week
-             * @property {Array} lastWeek
-             */
-            var lastWeek = [new Date(), new Date()];
-            lastWeek[0].setDate(lastWeek[0].getDate() - 14);
-            lastWeek[1].setDate(lastWeek[1].getDate() - 7);
+            $scope.filter.from = $scope.search.from || undefined;
+            $scope.filter.to = $scope.search.to || undefined;
 
             // set max datepicker date to be end of last week
-            $scope.datepickerMaxDate = lastWeek[1];
-
-            // default filter to last week
-            $scope.filter.from = $scope.search.from || lastWeek[0];
-            $scope.filter.to = $scope.search.to || lastWeek[1];
-
+            $scope.datepickerMaxDate = DateUtils.lastOccurence(5);
 
             // Format most active DJ stats for charts
             if (stats.most_active_djs) {  // jshint ignore:line
@@ -230,10 +272,12 @@ angular.module("FM.stats.StatsCtrl", [
                 });
             }
 
-            // Format total play time per user stats for charts
-            $scope.addDataToSeries($scope.playTime, stats.total_play_time_per_user, $filter("date")($scope.filter.from, "dd-MM-yyyy"));  // jshint ignore:line
-            // Load additional data for play time line chart
-            $scope.loadHistoricData($scope.filter.from, $scope.filter.to);
+            if ($scope.filter.from) {
+                // Format total play time per user stats for charts
+                $scope.addDataToSeries($scope.playTime, stats.total_play_time_per_user, $filter("date")($scope.filter.from, "dd-MM-yyyy"));  // jshint ignore:line
+                // Load additional data for play time line chart
+                $scope.loadHistoricData($scope.filter.from, $scope.filter.to);
+            }
         };
 
         $scope.init();

--- a/app/js/stats/services/DateUtils.js
+++ b/app/js/stats/services/DateUtils.js
@@ -1,0 +1,46 @@
+"use strict";
+/**
+ * @module   FM.stats.DateUtils
+ * @author   SOON_
+ */
+angular.module("FM.stats.DateUtils", [
+
+])
+/**
+ * Dates in last week
+ * @property {Array} LAST_WEEK
+ */
+.value("LAST_WEEK", [
+    new Date(),
+    new Date(new Date().setDate(new Date().getDate() - 1)),
+    new Date(new Date().setDate(new Date().getDate() - 2)),
+    new Date(new Date().setDate(new Date().getDate() - 3)),
+    new Date(new Date().setDate(new Date().getDate() - 4)),
+    new Date(new Date().setDate(new Date().getDate() - 5)),
+    new Date(new Date().setDate(new Date().getDate() - 6))
+])
+/**
+ * Date helper functions
+ * @class DateUtils
+ * @param   {Array}    LAST_WEEK
+ * @returns {Object}
+ */
+.service("DateUtils", [
+    "LAST_WEEK",
+    function (LAST_WEEK) {
+
+        /**
+         * Return last occurence of a day in the week
+         * @method lastOccurence
+         * @param {Number} dayOfWeek  Day of the week to retreive (0-6)
+         */
+        this.lastOccurence = function lastOccurence (dayOfWeek) {
+            for (var i = 0; i < LAST_WEEK.length; i++) {
+                if (LAST_WEEK[i].getDay() === dayOfWeek) {
+                    return LAST_WEEK[i];
+                }
+            }
+        };
+
+    }
+]);

--- a/app/js/stats/services/DateUtils.js
+++ b/app/js/stats/services/DateUtils.js
@@ -11,13 +11,13 @@ angular.module("FM.stats.DateUtils", [
  * @property {Array} LAST_WEEK
  */
 .value("LAST_WEEK", [
-    new Date(),
     new Date(new Date().setDate(new Date().getDate() - 1)),
     new Date(new Date().setDate(new Date().getDate() - 2)),
     new Date(new Date().setDate(new Date().getDate() - 3)),
     new Date(new Date().setDate(new Date().getDate() - 4)),
     new Date(new Date().setDate(new Date().getDate() - 5)),
-    new Date(new Date().setDate(new Date().getDate() - 6))
+    new Date(new Date().setDate(new Date().getDate() - 6)),
+    new Date(new Date().setDate(new Date().getDate() - 7))
 ])
 /**
  * Date helper functions

--- a/app/js/stats/services/StatsResolver.js
+++ b/app/js/stats/services/StatsResolver.js
@@ -1,9 +1,9 @@
 "use strict";
 /**
- * @module   FM.stats.StatsResolver
+ * @module   FM.stats.statsResolver
  * @author   SOON_
  */
-angular.module("FM.stats.StatsResolver", [
+angular.module("FM.stats.statsResolver", [
     "FM.stats.DateUtils",
     "FM.api.StatsResource",
     "ngRoute"
@@ -17,7 +17,7 @@ angular.module("FM.stats.StatsResolver", [
  * @param   {Service}  DateUtils     Date helper utilities
  * @returns {Promise}  Data resolved from API
  */
-.factory("StatsResolver", [
+.factory("statsResolver", [
     "$route",
     "$filter",
     "$location",
@@ -25,30 +25,27 @@ angular.module("FM.stats.StatsResolver", [
     "DateUtils",
     function ($route, $filter, $location, StatsResource, DateUtils) {
 
-        /**
-         * New route parameters
-         * @property {Object} params
-         */
-        var params = $route.current.params;
+        return function resolver(params){
+            /**
+             * Is the param `to` greater than last Friday
+             * @property {Boolean} toInvalid
+             */
+            var toInvalid = new Date(params.to) > DateUtils.lastOccurence(5);
 
-        /**
-         * Is the param `to` greater than last Friday
-         * @property {Boolean} toInvalid
-         */
-        var toInvalid = new Date(params.to) > DateUtils.lastOccurence(5);
+            // Restrict `to` search param to last Friday
+            if (!params.to || toInvalid) {
+                params.to = $filter("date")(DateUtils.lastOccurence(5), "yyyy-MM-dd");
+            }
 
-        // Restrict `to` search param to last Friday
-        if (!params.to || toInvalid) {
-            params.to = $filter("date")(DateUtils.lastOccurence(5), "yyyy-MM-dd");
-        }
+            // Set `from` default to last week
+            if (!params.from && !params.all) {
+                var defaultFrom = new Date().setDate(DateUtils.lastOccurence(5).getDate() - 7);
+                params.from = $filter("date")(defaultFrom, "yyyy-MM-dd");
+            }
 
-        // Set `from` default to last week
-        if (!params.from && !params.all) {
-            var defaultFrom = new Date().setDate(DateUtils.lastOccurence(5).getDate() - 7);
-            params.from = $filter("date")(defaultFrom, "yyyy-MM-dd");
-        }
-
-        $location.replace().search(params);
-        return StatsResource.get(params).$promise;
+            $location.replace().search(params);
+            delete params.all;
+            return StatsResource.get(params).$promise;
+        };
     }
 ]);

--- a/app/js/stats/services/StatsResolver.js
+++ b/app/js/stats/services/StatsResolver.js
@@ -1,0 +1,54 @@
+"use strict";
+/**
+ * @module   FM.stats.StatsResolver
+ * @author   SOON_
+ */
+angular.module("FM.stats.StatsResolver", [
+    "FM.stats.DateUtils",
+    "FM.api.StatsResource",
+    "ngRoute"
+])
+/**
+ * Factory to resolve statistics data, with parameter restrictions
+ * @param   {Object}   $route
+ * @param   {Service}  $filter
+ * @param   {String}   $location
+ * @param   {Resource} StatsResource Resource to provide communication with API
+ * @param   {Service}  DateUtils     Date helper utilities
+ * @returns {Promise}  Data resolved from API
+ */
+.factory("StatsResolver", [
+    "$route",
+    "$filter",
+    "$location",
+    "StatsResource",
+    "DateUtils",
+    function ($route, $filter, $location, StatsResource, DateUtils) {
+
+        /**
+         * New route parameters
+         * @property {Object} params
+         */
+        var params = $route.current.params;
+
+        /**
+         * Is the param `to` greater than last Friday
+         * @property {Boolean} toInvalid
+         */
+        var toInvalid = new Date(params.to) > DateUtils.lastOccurence(5);
+
+        // Restrict `to` search param to last Friday
+        if (!params.to || toInvalid) {
+            params.to = $filter("date")(DateUtils.lastOccurence(5), "yyyy-MM-dd");
+        }
+
+        // Set `from` default to last week
+        if (!params.from && !params.all) {
+            var defaultFrom = new Date().setDate(DateUtils.lastOccurence(5).getDate() - 7);
+            params.from = $filter("date")(defaultFrom, "yyyy-MM-dd");
+        }
+
+        $location.replace().search(params);
+        return StatsResource.get(params).$promise;
+    }
+]);

--- a/app/js/stats/stats.js
+++ b/app/js/stats/stats.js
@@ -5,7 +5,7 @@
  */
 angular.module("FM.stats", [
     "FM.stats.StatsCtrl",
-    "FM.stats.timeFilter"
+    "FM.stats.DateUtils"
 ])
 /**
  * Colour scheme for charts

--- a/app/js/stats/stats.js
+++ b/app/js/stats/stats.js
@@ -5,7 +5,8 @@
  */
 angular.module("FM.stats", [
     "FM.stats.StatsCtrl",
-    "FM.stats.DateUtils"
+    "FM.stats.DateUtils",
+    "FM.stats.StatsResolver"
 ])
 /**
  * Colour scheme for charts

--- a/app/js/stats/stats.js
+++ b/app/js/stats/stats.js
@@ -6,7 +6,7 @@
 angular.module("FM.stats", [
     "FM.stats.StatsCtrl",
     "FM.stats.DateUtils",
-    "FM.stats.StatsResolver"
+    "FM.stats.statsResolver"
 ])
 /**
  * Colour scheme for charts

--- a/app/partials/stats.html
+++ b/app/partials/stats.html
@@ -51,7 +51,8 @@
                 <canvas id="line" class="chart chart-line" data="playTime.data" series="playTime.series" labels="playTime.labels" series="playTime.series" colours="chartColours"></canvas>
 
                 <h2 class="text-center">Play time</h2>
-                <p class="text-center">{{ playTime.series[0] }} <span ng-if="playTime.data[0][0] >= 1440">{{ playTime.data[0][0]/60 }} hours</span><span ng-if="playTime.data[0][0] < 1440">{{ playTime.data[0][0] }} minutes</span></p>
+                <p class="text-center" ng-if="playTime.data[0][0]">{{ playTime.series[0] }} <span ng-if="playTime.data[0][0] >= 1440">{{ playTime.data[0][0]/60 }} hours</span><span ng-if="playTime.data[0][0] < 1440">{{ playTime.data[0][0] }} minutes</span></p>
+                <p class="text-center" ng-if="!playTime.data[0][0]">Select from date to view historic play time stats</p>
 
             </div>
         </div>

--- a/scripts.json
+++ b/scripts.json
@@ -68,6 +68,7 @@
         "./app/js/stats/stats.js",
         "./app/js/stats/controllers/StatsCtrl.js",
         "./app/js/stats/filters/time.js",
+        "./app/js/stats/services/DateUtils.js",
 
         "./app/js/nav/nav.js",
 

--- a/scripts.json
+++ b/scripts.json
@@ -69,6 +69,7 @@
         "./app/js/stats/controllers/StatsCtrl.js",
         "./app/js/stats/filters/time.js",
         "./app/js/stats/services/DateUtils.js",
+        "./app/js/stats/services/StatsResolver.js",
 
         "./app/js/nav/nav.js",
 

--- a/tests/unit/stats/controllers/StatsCtrl.js
+++ b/tests/unit/stats/controllers/StatsCtrl.js
@@ -42,6 +42,9 @@ describe("FM.stats.StatsCtrl", function() {
         CHART_COLOURS = [];
         CHART_OPTIONS = {};
 
+        var today = new Date("2015-07-01");
+        jasmine.clock().mockDate(today);
+
         $controller("StatsCtrl", {
             $scope: $scope,
             $q: $q,
@@ -88,41 +91,41 @@ describe("FM.stats.StatsCtrl", function() {
         expect($scope.datepickerOpened.test).toBe(false);
     });
 
-    it("should update filter", function(){
-        $httpBackend.flush();
+    describe("filter", function () {
 
-        // filter as js dates
-        $scope.filter = {
-            from: new Date("2015-07-01"),
-            to: new Date("2015-07-02")
-        };
-        $scope.updateFilter();
-        expect($location.search).toHaveBeenCalledWith({
-            from: "2015-07-01",
-            to: "2015-07-02"
+        it("should filter from JS dates", function(){
+            $httpBackend.flush();
+            $scope.filter = {
+                from: new Date("2015-07-01"),
+                to: new Date("2015-07-02")
+            };
+            $scope.updateFilter();
+            expect($location.search).toHaveBeenCalledWith({
+                from: "2015-07-01",
+                to: "2015-07-02"
+            });
         });
 
-        // filter as date strings
-        $scope.filter = { from: "2015-07-01", to: "2015-07-02" };
-        $scope.updateFilter();
-        expect($location.search).toHaveBeenCalledWith({
-            from: "2015-07-01",
-            to: "2015-07-02"
+        it("should filter from date strings", function(){
+            $httpBackend.flush();
+            $scope.filter = { from: "2015-07-01", to: "2015-07-02" };
+            $scope.updateFilter();
+            expect($location.search).toHaveBeenCalledWith({
+                from: "2015-07-01",
+                to: "2015-07-02"
+            });
         });
+
+        it("should clear filters", function(){
+            $httpBackend.flush();
+            $scope.filter = { from: undefined, to: undefined };
+            $scope.updateFilter();
+            expect($location.search).toHaveBeenCalledWith({ from: undefined, to: undefined, all: true });
+        });
+
     });
 
     describe("init", function () {
-
-        it("should default filter to last week", function(){
-            var today = new Date("2015-07-01");
-            jasmine.clock().mockDate(today);
-            $scope.search = {};
-
-            $scope.init();
-            $httpBackend.flush();
-            expect($scope.filter.from).toEqual(new Date("2015-06-17"));
-            expect($scope.filter.to).toEqual(new Date("2015-06-24"));
-        });
 
         it("should add active DJ data to dataset", function(){
             $httpBackend.flush();

--- a/tests/unit/stats/services/DateUtils.js
+++ b/tests/unit/stats/services/DateUtils.js
@@ -1,0 +1,38 @@
+"use strict";
+
+describe("FM.stats.DateUtils", function() {
+
+    var $scope, DateUtils, LAST_WEEK;
+
+    beforeEach(module("FM.stats.DateUtils"));
+
+    beforeEach(module(function($provide) {
+        $provide.value("LAST_WEEK", [
+            new Date("2015-07-08"),
+            new Date(new Date().setDate(new Date("2015-07-08").getDate() - 1)),
+            new Date(new Date().setDate(new Date("2015-07-08").getDate() - 2)),
+            new Date(new Date().setDate(new Date("2015-07-08").getDate() - 3)),
+            new Date(new Date().setDate(new Date("2015-07-08").getDate() - 4)),
+            new Date(new Date().setDate(new Date("2015-07-08").getDate() - 5)),
+            new Date(new Date().setDate(new Date("2015-07-08").getDate() - 6))
+        ]);
+    }));
+
+    beforeEach(inject(function ( $rootScope, $injector, $controller ) {
+        $scope = $rootScope.$new();
+
+        DateUtils = $injector.get("DateUtils");
+    }));
+
+
+    describe("lastOccurence", function(){
+
+        it("should return last occurence of specific day of the week", function(){
+            jasmine.clock().tick(1);
+            var lastFriday = DateUtils.lastOccurence(5);
+            expect(lastFriday).toEqual(new Date("2015-07-03"));
+        });
+
+    });
+
+});

--- a/tests/unit/stats/services/StatsResolver.js
+++ b/tests/unit/stats/services/StatsResolver.js
@@ -1,0 +1,42 @@
+"use strict";
+
+describe("FM.stats.statsResolver", function (){
+    var statsResolver, StatsResource, DateUtils;
+
+    beforeEach(module("FM.stats.statsResolver"));
+
+    beforeEach(inject(function ( $injector, $route ){
+        statsResolver = $injector.get("statsResolver");
+        StatsResource = $injector.get("StatsResource");
+        spyOn(StatsResource, "get").and.callThrough();
+
+        DateUtils = $injector.get("DateUtils");
+        DateUtils.lastOccurence = function () {
+            // mock last Friday
+            return new Date("2015-07-17");
+        };
+
+    }));
+
+    it("should set filter params", function(){
+        statsResolver({ to: "2015-07-10", from: "2015-07-06" });
+        expect(StatsResource.get).toHaveBeenCalledWith({ to: "2015-07-10", from: "2015-07-06" });
+    });
+
+    it("should default filter params to last week", function(){
+        statsResolver({});
+        expect(StatsResource.get).toHaveBeenCalledWith({ to: "2015-07-17", from: "2015-07-10" });
+    });
+
+    it("should restrict max `to` date to last friday", function(){
+        statsResolver({ to: "2015-07-24" });
+        expect(StatsResource.get).toHaveBeenCalledWith({ to: "2015-07-17", from: "2015-07-10" });
+    });
+
+    it("should NOT default from if `all` param set", function(){
+        statsResolver({ to: "2015-07-10", all: true });
+        expect(StatsResource.get).toHaveBeenCalledWith({ to: "2015-07-10" });
+    });
+
+});
+


### PR DESCRIPTION
This PR improves the stat filtering:
- `DateUtils` helper service with method to determine the date of last Friday - this allows us to set filter limits and defaults based on actual week rather than just `today - 7 days`. (fixes #162)
- Set filter defaults in new `statsResolver` - this allows us to set defaults and restrict date filter params before the data is fetched (fixes #159)
- Currently users can access the current week stats if they manually set the filter params in the URL, the new `statsResolver` fixes that.
- Clearing the filters now shows the stats from all of time up to last Friday (fixes #161)