### PR TITLE
Fix: Spotify Authentication

### DIFF
--- a/app/js/api/factories/RequestInterceptor.js
+++ b/app/js/api/factories/RequestInterceptor.js
@@ -96,7 +96,7 @@ angular.module("FM.api.RequestInterceptor", [
                     $window.localStorage.removeItem(tokenName);
                 }
 
-                if($rootScope.routeChanging){
+                if($rootScope.routeChanging && !response.config.url.match(/api.spotify.com\/v1\/me/)){
 
                     // Navigate to error pages if server returns error code whilst FE route is changing
                     if (response.status === 401){

--- a/tests/unit/auth/services/SpotifyAuthService.js
+++ b/tests/unit/auth/services/SpotifyAuthService.js
@@ -2,8 +2,9 @@
 
 describe("FM.auth.SpotifyAuthService", function() {
 
-    var service, $httpBackend, $rootScope, $window, $q, ERRORS, Spotify, AlertService, TOKEN_NAME, token,
-        fakeSpotifyLoginCallback, fakeGetItemCallback, message, user, userRequest;
+    var service, $httpBackend, $rootScope, $window, $q, ERRORS, Spotify, AlertService, TOKEN_NAME,
+        fakeSpotifyLoginCallback, fakeGetItemCallback,
+        spotifyResponse, user, token, userRequest;
 
     window.localStorage = {};
 
@@ -23,15 +24,12 @@ describe("FM.auth.SpotifyAuthService", function() {
 
     beforeEach(inject(function ( _$rootScope_, $injector ) {
 
+        spotifyResponse = [token];
+
         fakeSpotifyLoginCallback = function(){
             return {
                 then: function(fn){
                     fn.apply(this, [token]);
-                    return fakeSpotifyLoginCallback();
-                },
-                catch: function(fn){
-                    fn.apply(this, [{ message: message, errors: { code: 400 } }]);
-                    return fakeSpotifyLoginCallback();
                 }
             }
         }
@@ -43,12 +41,14 @@ describe("FM.auth.SpotifyAuthService", function() {
         $rootScope = _$rootScope_;
 
         $window = $injector.get("$window");
-        $window.localStorage = {}
+        $window.localStorage = {};
         spyOn($window.localStorage, "getItem").and.callFake(fakeGetItemCallback);
         spyOn($window.localStorage, "setItem").and.callFake(fakeGetItemCallback);
+        spyOn($window.localStorage, "removeItem").and.callFake(fakeGetItemCallback);
 
         Spotify = $injector.get("Spotify");
         spyOn(Spotify, "login").and.callFake(fakeSpotifyLoginCallback);
+        spyOn(Spotify, "getUser").and.callThrough();
 
         AlertService = $injector.get("AlertService");
         $q = $injector.get("$window");
@@ -56,8 +56,6 @@ describe("FM.auth.SpotifyAuthService", function() {
         TOKEN_NAME = $injector.get("TOKEN_NAME");
 
         token = undefined;
-
-        message = "Validation Error";
 
         service = $injector.get("SpotifyAuth");
 
@@ -70,21 +68,54 @@ describe("FM.auth.SpotifyAuthService", function() {
 
     it("should attempt to get current user if auth token exists", function () {
         var setAuthTokenSpy = spyOn(Spotify, "setAuthToken");
-        var getUserSpy = spyOn(service, "getCurrentUser");
+        var getUserSpy = spyOn(service, "getCurrentUser").and.callThrough();
         token = "foo";
 
         service.init();
+        $httpBackend.flush();
+        $rootScope.$digest();
+
         expect(setAuthTokenSpy).toHaveBeenCalledWith(token);
         expect(getUserSpy).toHaveBeenCalled();
-    })
+    });
 
     it("should NOT attempt to get current user if auth token doesn't exists", function () {
         var setAuthTokenSpy = spyOn(Spotify, "setAuthToken");
         var getUserSpy = spyOn(service, "getCurrentUser");
 
         service.init();
+        $rootScope.$digest();
         expect(setAuthTokenSpy).not.toHaveBeenCalled();
         expect(getUserSpy).not.toHaveBeenCalled();
+    });
+
+    it("should authenticate the user if token has expired", function () {
+        var setAuthTokenSpy = spyOn(Spotify, "setAuthToken"),
+            getUserSpy = spyOn(service, "getCurrentUser").and.callThrough(),
+            authSpy = spyOn(service, "authenticate");
+
+        user = { error: { status: 401 } };
+        userRequest.respond(200, user);
+        token = "foo";
+
+        service.init();
+        $httpBackend.flush();
+        $rootScope.$digest();
+
+        expect(setAuthTokenSpy).toHaveBeenCalled();
+        expect(getUserSpy).toHaveBeenCalled();
+        expect(authSpy).toHaveBeenCalled();
+
+        user = { error: { status: 404 } };
+        userRequest.respond(200, user);
+
+        service.init();
+        $httpBackend.flush();
+        $rootScope.$digest();
+
+        expect(setAuthTokenSpy.calls.count()).toEqual(2);
+        expect(getUserSpy.calls.count()).toEqual(2);
+        expect(authSpy.calls.count()).toEqual(1);
     });
 
     it("should return authentication status", function () {
@@ -100,20 +131,27 @@ describe("FM.auth.SpotifyAuthService", function() {
     });
 
     it("should attempt to authenticate user", function () {
+        token = "foo";
         var setAuthTokenSpy = spyOn(Spotify, "setAuthToken");
         service.authenticate();
         $rootScope.$digest();
 
         expect(setAuthTokenSpy).toHaveBeenCalledWith(token);
         expect($window.localStorage.setItem).toHaveBeenCalledWith(TOKEN_NAME, token);
+    });
 
-        message = "";
-
+    it("should attempt to authenticate user and handle error", function () {
+        token = { error: { status: 401 } };
+        var setAuthTokenSpy = spyOn(Spotify, "setAuthToken");
+        var alertSpy = spyOn(AlertService, "set");
         service.authenticate();
         $rootScope.$digest();
 
-        expect(setAuthTokenSpy.calls.count()).toBe(2);
-        expect($window.localStorage.setItem.calls.count()).toBe(2);
+        expect(setAuthTokenSpy).not.toHaveBeenCalled();
+        expect($window.localStorage.setItem).not.toHaveBeenCalled();
+        expect(alertSpy).toHaveBeenCalled();
+        expect(service.authenticated).toBeFalsy();
+        expect($window.localStorage.removeItem).toHaveBeenCalledWith(TOKEN_NAME);
     });
 
     it("should get the current user", function () {
@@ -134,47 +172,6 @@ describe("FM.auth.SpotifyAuthService", function() {
         $httpBackend.flush();
         $rootScope.$digest();
         expect(service.user).toBeNull();
-
-        var authSpy = spyOn(service, "authenticate")
-
-        authSpy.and.callFake(function(){
-            return {
-                then: function(){
-                    return {
-                        catch: function(fn){
-                            fn.apply(this,[{}]);
-                        }
-                    }
-                }
-            }
-        });
-
-        service.user = { id: "foo" };
-
-        service.getCurrentUser();
-        $httpBackend.flush();
-        $rootScope.$digest();
-        expect(service.user).toBeNull();
-
-        authSpy.and.callFake(function(){
-            return {
-                then: function(fn){
-                    userRequest.respond(200, user);
-                    fn.apply(this,[{}]);
-                    return {
-                        catch: function(fn){}
-                    }
-                }
-            }
-        });
-
-        service.user = null;
-
-        service.getCurrentUser();
-        $httpBackend.flush();
-        $rootScope.$digest();
-        expect(service.user).toEqual(user);
-
     });
 
 });


### PR DESCRIPTION
The PR fixes an issue with Spotify authentication flow when the token has expired. The FE will now request a new token when the token expires. 