### PR TITLE
Fix: stat default from

### DIFF
--- a/app/js/stats/services/DateUtils.js
+++ b/app/js/stats/services/DateUtils.js
@@ -11,13 +11,13 @@ angular.module("FM.stats.DateUtils", [
  * @property {Array} LAST_WEEK
  */
 .value("LAST_WEEK", [
-    new Date(new Date().setDate(new Date().getDate() - 1)),
-    new Date(new Date().setDate(new Date().getDate() - 2)),
-    new Date(new Date().setDate(new Date().getDate() - 3)),
-    new Date(new Date().setDate(new Date().getDate() - 4)),
-    new Date(new Date().setDate(new Date().getDate() - 5)),
-    new Date(new Date().setDate(new Date().getDate() - 6)),
-    new Date(new Date().setDate(new Date().getDate() - 7))
+    new Date(new Date().getTime() - (86400000)),
+    new Date(new Date().getTime() - (2*86400000)),
+    new Date(new Date().getTime() - (3*86400000)),
+    new Date(new Date().getTime() - (4*86400000)),
+    new Date(new Date().getTime() - (5*86400000)),
+    new Date(new Date().getTime() - (6*86400000)),
+    new Date(new Date().getTime() - (7*86400000))
 ])
 /**
  * Date helper functions

--- a/app/js/stats/services/StatsResolver.js
+++ b/app/js/stats/services/StatsResolver.js
@@ -26,6 +26,13 @@ angular.module("FM.stats.statsResolver", [
     function ($route, $filter, $location, StatsResource, DateUtils) {
 
         return function resolver(params){
+
+            /**
+             * The date last friday
+             * @property {Date} lastFriday
+             */
+            var lastFriday = DateUtils.lastOccurence(5);
+
             /**
              * Is the param `to` greater than last Friday
              * @property {Boolean} toInvalid
@@ -38,8 +45,8 @@ angular.module("FM.stats.statsResolver", [
             }
 
             // Set `from` default to last week
-            if (!params.from && !params.all) {
-                var defaultFrom = new Date().setDate(DateUtils.lastOccurence(5).getDate() - 7);
+            if ((!params.from && !params.all) || fromInvalid) {
+                var defaultFrom = new Date(lastFriday - (7 * 86400000));
                 params.from = $filter("date")(defaultFrom, "yyyy-MM-dd");
             }
 

--- a/app/js/stats/services/StatsResolver.js
+++ b/app/js/stats/services/StatsResolver.js
@@ -37,11 +37,17 @@ angular.module("FM.stats.statsResolver", [
              * Is the param `to` greater than last Friday
              * @property {Boolean} toInvalid
              */
-            var toInvalid = new Date(params.to) > DateUtils.lastOccurence(5);
+            var toInvalid = new Date(params.to) > lastFriday;
+
+            /**
+             * Is the param `from` greater than last Friday
+             * @property {Boolean} fromInvalid
+             */
+            var fromInvalid = new Date(params.from) > lastFriday;
 
             // Restrict `to` search param to last Friday
             if (!params.to || toInvalid) {
-                params.to = $filter("date")(DateUtils.lastOccurence(5), "yyyy-MM-dd");
+                params.to = $filter("date")(lastFriday, "yyyy-MM-dd");
             }
 
             // Set `from` default to last week

--- a/tests/unit/stats/services/DateUtils.js
+++ b/tests/unit/stats/services/DateUtils.js
@@ -8,13 +8,13 @@ describe("FM.stats.DateUtils", function() {
 
     beforeEach(module(function($provide) {
         $provide.value("LAST_WEEK", [
-            new Date("2015-07-08"),
-            new Date(new Date().setDate(new Date("2015-07-08").getDate() - 1)),
-            new Date(new Date().setDate(new Date("2015-07-08").getDate() - 2)),
-            new Date(new Date().setDate(new Date("2015-07-08").getDate() - 3)),
-            new Date(new Date().setDate(new Date("2015-07-08").getDate() - 4)),
-            new Date(new Date().setDate(new Date("2015-07-08").getDate() - 5)),
-            new Date(new Date().setDate(new Date("2015-07-08").getDate() - 6))
+            new Date(new Date("2015-07-08").getTime() - (86400000)),
+            new Date(new Date("2015-07-08").getTime() - (2*86400000)),
+            new Date(new Date("2015-07-08").getTime() - (3*86400000)),
+            new Date(new Date("2015-07-08").getTime() - (4*86400000)),
+            new Date(new Date("2015-07-08").getTime() - (5*86400000)),
+            new Date(new Date("2015-07-08").getTime() - (6*86400000)),
+            new Date(new Date("2015-07-08").getTime() - (7*86400000))
         ]);
     }));
 
@@ -30,10 +30,24 @@ describe("FM.stats.DateUtils", function() {
 
     describe("lastOccurence", function(){
 
-        it("should return last occurence of specific day of the week", function(){
+        it("should return last occurence of friday", function(){
             jasmine.clock().tick(1);
             var lastFriday = DateUtils.lastOccurence(5);
             expect(lastFriday).toEqual(new Date("2015-07-03"));
+        });
+
+        // check beginning of week boundary
+        it("should return last occurence of wednesday", function(){
+            jasmine.clock().tick(1);
+            var lastWednesday = DateUtils.lastOccurence(3);
+            expect(lastWednesday).toEqual(new Date("2015-07-01"));
+        });
+
+        // check end of week boundary
+        it("should return last occurence of tuesday", function(){
+            jasmine.clock().tick(1);
+            var tuesday = DateUtils.lastOccurence(2);
+            expect(tuesday).toEqual(new Date("2015-07-07"));
         });
 
     });

--- a/tests/unit/stats/services/StatsResolver.js
+++ b/tests/unit/stats/services/StatsResolver.js
@@ -33,6 +33,11 @@ describe("FM.stats.statsResolver", function (){
         expect(StatsResource.get).toHaveBeenCalledWith({ to: "2015-07-17", from: "2015-07-10" });
     });
 
+    it("should restrict max `from` date to last friday", function(){
+        statsResolver({ from: "2015-08-10" });
+        expect(StatsResource.get).toHaveBeenCalledWith({ to: "2015-07-17", from: "2015-07-10" });
+    });
+
     it("should NOT default from if `all` param set", function(){
         statsResolver({ to: "2015-07-10", all: true });
         expect(StatsResource.get).toHaveBeenCalledWith({ to: "2015-07-10" });


### PR DESCRIPTION
There is an issue with the method used to determine the dates of last week, it did not set the month correctly. This fixes it by using time based date calculation instead. I've also added restriction to the stats from date, so it can not be in the future. Fixes #200 