### PR TITLE
Fix: spotify auth when has expired

### DIFF
--- a/app/js/auth/services/SpotifyAuthService.js
+++ b/app/js/auth/services/SpotifyAuthService.js
@@ -96,12 +96,13 @@ angular.module("FM.auth.SpotifyAuthService", [
 
             Spotify.getCurrentUser()
                 .then(function (response){
-                    user = response;
-                    deferred.resolve(response);
-                })
-                .catch(function (response){
-                    user = null;
-                    deferred.reject(response);
+                    if (response && !response.error){
+                        user = response;
+                        deferred.resolve(response);
+                    } else {
+                        user = null;
+                        deferred.reject(response);
+                    }
                 });
 
             return deferred.promise;

--- a/app/js/auth/services/SpotifyAuthService.js
+++ b/app/js/auth/services/SpotifyAuthService.js
@@ -110,54 +110,12 @@ angular.module("FM.auth.SpotifyAuthService", [
 
         /**
          * Authenticate with spotify OAuth
-         * @private
-         * @method authenticateOnlyIfToken
-         * @return {Object} Spotify user object
-         */
-        var authenticateOnlyIfToken = function authenticateOnlyIfToken() {
-            var deferred = $q.defer(),
-                authToken = $window.localStorage.getItem(TOKEN_NAME);
-
-            // check for existing auth token
-            if (authToken){
-                Spotify.setAuthToken(authToken);
-
-                getCurrentUser()
-                    .then(function (){
-                        authenticated = true;
-                        deferred.resolve(authToken);
-                    })
-                    .catch(function (response){
-
-                        if (response && response.error && response.error.status === 401){
-                            login()
-                                .then(function (response){
-                                    authenticated = true;
-                                    deferred.resolve(response);
-                                })
-                                .catch(function (response){
-                                    authenticated = false;
-                                    deferred.reject(response);
-                                });
-                        } else {
-                            deferred.reject(response);
-                        }
-                    });
-
-            } else {
-                deferred.reject();
-            }
-
-            return deferred.promise;
-        };
-
-        /**
-         * Authenticate with spotify OAuth
          * @public
          * @method authenticate
-         * @return {Object} Spotify user object
+         * @param  {Boolean} onlyIfToken only request auth if user token exists
+         * @return {Object}  Spotify     user object
          */
-        this.authenticate = function authenticate() {
+        this.authenticate = function authenticate(onlyIfToken) {
             var deferred = $q.defer(),
                 authToken = $window.localStorage.getItem(TOKEN_NAME);
 
@@ -183,15 +141,19 @@ angular.module("FM.auth.SpotifyAuthService", [
                     });
 
             } else {
-                login()
-                    .then(function (response){
-                        authenticated = true;
-                        deferred.resolve(response);
-                    })
-                    .catch(function (response){
-                        authenticated = false;
-                        deferred.reject(response);
-                    });
+                if (!onlyIfToken){
+                    login()
+                        .then(function (response){
+                            authenticated = true;
+                            deferred.resolve(response);
+                        })
+                        .catch(function (response){
+                            authenticated = false;
+                            deferred.reject(response);
+                        });
+                } else {
+                    deferred.reject();
+                }
             }
 
             return deferred.promise;
@@ -216,7 +178,7 @@ angular.module("FM.auth.SpotifyAuthService", [
         this.getUser = function getUser() {
             var deferred = $q.defer();
 
-            authenticateOnlyIfToken()
+            _this.authenticate(true)
                 .then(function (){
                     getCurrentUser()
                         .then(deferred.resolve)
@@ -255,7 +217,7 @@ angular.module("FM.auth.SpotifyAuthService", [
          * @method init
          */
         this.init = function init() {
-            authenticateOnlyIfToken();
+            _this.authenticate(true);
         };
 
     }

--- a/tests/unit/auth/services/SpotifyAuthService.js
+++ b/tests/unit/auth/services/SpotifyAuthService.js
@@ -25,7 +25,7 @@ describe("FM.auth.SpotifyAuthService", function() {
         playlists = [{ id: "123" }, { id: "456" }];
 
         userPlaylistRequest = $httpBackend.whenGET(/.*api.spotify.com\/v1\/users\/.*\/playlists/);
-        userRequest = $httpBackend.whenGET(/.*api.spotify.com\/v1\/me.*/);
+        userRequest = $httpBackend.whenGET(/.*api.spotify.com\/v1\/me/);
 
         userRequest.respond(200, user);
         userPlaylistRequest.respond(200, playlists);
@@ -170,7 +170,7 @@ describe("FM.auth.SpotifyAuthService", function() {
         // user has local token, token is expired, token is renewed
         var error = { error: { status: 401 } };
         token = "foo";
-        userRequest.respond(401, error);
+        userRequest.respond(200, error);
         var setAuthTokenSpy = spyOn(Spotify, "setAuthToken");
         var alertSpy = spyOn(AlertService, "set");
 
@@ -194,7 +194,7 @@ describe("FM.auth.SpotifyAuthService", function() {
         expect(service.isAuthenticated()).toBeTruthy();
 
         // user has local token, token is expired, token renewal fails
-        userRequest.respond(401, error);
+        userRequest.respond(200, error);
         spotifyLoginResponse = error;
 
         service.authenticate();


### PR DESCRIPTION
This PR fixes an issue with Spotify authentication when the users token has expired. This should renew the token automatically for the user.