### PR TITLE
Fix: Hide playlist link when not logged in to spotify

### DIFF
--- a/app/js/auth/controllers/LoginGoogleCtrl.js
+++ b/app/js/auth/controllers/LoginGoogleCtrl.js
@@ -34,6 +34,12 @@ angular.module("FM.auth.LoginGoogleCtrl", [
     function ($scope, $route, $auth, ERRORS, AlertService, GoogleAuthService) {
 
         /**
+         * @property currentUser
+         * @type {Object}
+         */
+        $scope.currentUser = GoogleAuthService.getUser();
+
+        /**
          * Authenticate with google oauth
          * @method authenticate
          */

--- a/app/partials/users/nav.html
+++ b/app/partials/users/nav.html
@@ -1,5 +1,5 @@
 <nav class="row">
-    <ul class="nav nav-tabs">
+    <ul class="nav nav-tabs" ng-controller="LoginGoogleCtrl">
         <li role="presentation"
             ng-class="{
                 'active': routeIsActive('/users/' + user.id)
@@ -7,6 +7,7 @@
             <a ng-href="./users/{{ user.id }}">Stats</a>
         </li>
         <li role="presentation"
+            ng-if="currentUser.id === user.id"
             ng-controller="LoginSpotifyCtrl"
             ng-class="{
                 'active': routeIsActive('/users/' + user.id + '/playlists')

--- a/app/partials/users/nav.html
+++ b/app/partials/users/nav.html
@@ -1,6 +1,17 @@
 <nav class="row">
     <ul class="nav nav-tabs">
-        <li role="presentation" ng-class="{ 'active': routeIsActive('/users/' + user.id) }"><a ng-href="./users/{{ user.id }}">Stats</a></li>
-        <li role="presentation" ng-class="{ 'active': routeIsActive('/users/' + user.id + '/playlists') }"><a ng-href="./users/{{ user.id }}/playlists">Playlists</a></li>
+        <li role="presentation"
+            ng-class="{
+                'active': routeIsActive('/users/' + user.id)
+            }">
+            <a ng-href="./users/{{ user.id }}">Stats</a>
+        </li>
+        <li role="presentation"
+            ng-controller="LoginSpotifyCtrl"
+            ng-class="{
+                'active': routeIsActive('/users/' + user.id + '/playlists')
+            }">
+            <a ng-if="isAuthenticated()" ng-href="./users/{{ user.id }}/playlists">Playlists</a>
+        </li>
     </ul>
 </nav>


### PR DESCRIPTION
Hide the playlist link in the user profile view unless the user is logged in to Spotify and it is their own profile they are looking at.