### PR TITLE
Fix: user stats filter

### DIFF
--- a/app/js/stats/controllers/StatsCtrl.js
+++ b/app/js/stats/controllers/StatsCtrl.js
@@ -24,8 +24,8 @@ angular.module("FM.stats.StatsCtrl", [
                 templateUrl: "partials/stats.html",
                 controller: "StatsCtrl",
                 resolve: {
-                    stats: ["statsResolver", "$route", function (statsResolver, $route) {
-                        return statsResolver($route.current.params);
+                    stats: ["statsResolver", "$route", "StatsResource", function (statsResolver, $route, StatsResource) {
+                        return statsResolver(StatsResource.get, $route.current.params);
                     }]
                 }
             });

--- a/app/js/stats/services/StatsResolver.js
+++ b/app/js/stats/services/StatsResolver.js
@@ -5,7 +5,6 @@
  */
 angular.module("FM.stats.statsResolver", [
     "FM.stats.DateUtils",
-    "FM.api.StatsResource",
     "ngRoute"
 ])
 /**
@@ -13,7 +12,6 @@ angular.module("FM.stats.statsResolver", [
  * @param   {Object}   $route
  * @param   {Service}  $filter
  * @param   {String}   $location
- * @param   {Resource} StatsResource Resource to provide communication with API
  * @param   {Service}  DateUtils     Date helper utilities
  * @returns {Promise}  Data resolved from API
  */
@@ -21,11 +19,15 @@ angular.module("FM.stats.statsResolver", [
     "$route",
     "$filter",
     "$location",
-    "StatsResource",
     "DateUtils",
-    function ($route, $filter, $location, StatsResource, DateUtils) {
+    function ($route, $filter, $location, DateUtils) {
 
-        return function resolver(params){
+        /**
+         * Resolve stats from resource with restricted from/to parameters
+         * @param {Function} resource API resource action to resolve stats from eg. StatsResource.get
+         * @param {Object}   params   Current search params
+         */
+        return function resolver(resource, params){
 
             /**
              * The date last friday
@@ -58,7 +60,7 @@ angular.module("FM.stats.statsResolver", [
 
             $location.replace().search(params);
             delete params.all;
-            return StatsResource.get(params).$promise;
+            return resource(params).$promise;
         };
     }
 ]);

--- a/app/js/users/controllers/UserStatsCtrl.js
+++ b/app/js/users/controllers/UserStatsCtrl.js
@@ -23,8 +23,8 @@ angular.module("FM.users.UserStatsCtrl", [
                 templateUrl: "partials/users/stats.html",
                 controller: "UserStatsCtrl",
                 resolve: {
-                    stats: ["UsersResource", "$route", function (UsersResource, $route){
-                        return UsersResource.stats($route.current.params).$promise;
+                    stats: ["statsResolver", "$route", "UsersResource", function (statsResolver, $route, UsersResource) {
+                        return statsResolver(UsersResource.stats, $route.current.params);
                     }],
                     user: ["UsersResource", "$route", function (UsersResource, $route){
                         return UsersResource.get($route.current.params).$promise;

--- a/app/js/users/controllers/UserStatsCtrl.js
+++ b/app/js/users/controllers/UserStatsCtrl.js
@@ -174,7 +174,7 @@ angular.module("FM.users.UserStatsCtrl", [
             $scope.filter.to = $scope.search.to || undefined;
 
             // set max datepicker date to today
-            $scope.datepickerMaxDate = new Date();
+            $scope.datepickerMaxDate = DateUtils.lastOccurence(5);
 
             if ($scope.filter.from) {
                 // Format total play time per user stats for charts

--- a/tests/unit/stats/services/StatsResolver.js
+++ b/tests/unit/stats/services/StatsResolver.js
@@ -1,14 +1,19 @@
 "use strict";
 
 describe("FM.stats.statsResolver", function (){
-    var statsResolver, StatsResource, DateUtils;
+    var statsResolver, resource, mockResource, DateUtils;
 
     beforeEach(module("FM.stats.statsResolver"));
 
     beforeEach(inject(function ( $injector, $route ){
+        mockResource = function () {
+            return {
+                $promise: {}
+            }
+        };
+
         statsResolver = $injector.get("statsResolver");
-        StatsResource = $injector.get("StatsResource");
-        spyOn(StatsResource, "get").and.callThrough();
+        resource = jasmine.createSpy('resource').and.callFake(mockResource);
 
         DateUtils = $injector.get("DateUtils");
         DateUtils.lastOccurence = function () {
@@ -19,28 +24,28 @@ describe("FM.stats.statsResolver", function (){
     }));
 
     it("should set filter params", function(){
-        statsResolver({ to: "2015-07-10", from: "2015-07-06" });
-        expect(StatsResource.get).toHaveBeenCalledWith({ to: "2015-07-10", from: "2015-07-06" });
+        statsResolver(resource, { to: "2015-07-10", from: "2015-07-06" });
+        expect(resource).toHaveBeenCalledWith({ to: "2015-07-10", from: "2015-07-06" });
     });
 
     it("should default filter params to last week", function(){
-        statsResolver({});
-        expect(StatsResource.get).toHaveBeenCalledWith({ to: "2015-07-17", from: "2015-07-10" });
+        statsResolver(resource, {});
+        expect(resource).toHaveBeenCalledWith({ to: "2015-07-17", from: "2015-07-10" });
     });
 
     it("should restrict max `to` date to last friday", function(){
-        statsResolver({ to: "2015-07-24" });
-        expect(StatsResource.get).toHaveBeenCalledWith({ to: "2015-07-17", from: "2015-07-10" });
+        statsResolver(resource, { to: "2015-07-24" });
+        expect(resource).toHaveBeenCalledWith({ to: "2015-07-17", from: "2015-07-10" });
     });
 
     it("should restrict max `from` date to last friday", function(){
-        statsResolver({ from: "2015-08-10" });
-        expect(StatsResource.get).toHaveBeenCalledWith({ to: "2015-07-17", from: "2015-07-10" });
+        statsResolver(resource, { from: "2015-08-10" });
+        expect(resource).toHaveBeenCalledWith({ to: "2015-07-17", from: "2015-07-10" });
     });
 
     it("should NOT default from if `all` param set", function(){
-        statsResolver({ to: "2015-07-10", all: true });
-        expect(StatsResource.get).toHaveBeenCalledWith({ to: "2015-07-10" });
+        statsResolver(resource, { to: "2015-07-10", all: true });
+        expect(resource).toHaveBeenCalledWith({ to: "2015-07-10" });
     });
 
 });


### PR DESCRIPTION
This PR makes the StatsResolver re-usable for different resources. When calling it the resource can be injected in `statsResolver(StatsResource.get, $route.current.params)`. This has been integrated into the `/users/:id/stats` to impose the same date filter restrictions as the `/stats` view. 

Fixes #218