### PR TITLE
Fix: Spotify authtication error message

### DIFF
--- a/app/js/api/factories/RequestInterceptor.js
+++ b/app/js/api/factories/RequestInterceptor.js
@@ -96,7 +96,7 @@ angular.module("FM.api.RequestInterceptor", [
                     $window.localStorage.removeItem(tokenName);
                 }
 
-                if($rootScope.routeChanging && !response.config.url.match(/api.spotify.com\/v1\/me/)){
+                if($rootScope.routeChanging){
 
                     // Navigate to error pages if server returns error code whilst FE route is changing
                     if (response.status === 401){

--- a/app/js/api/factories/UsersResource.js
+++ b/app/js/api/factories/UsersResource.js
@@ -29,7 +29,7 @@ angular.module("FM.api.UsersResource",[
             {
                 current: {
                     method: "GET",
-                    url: env.FM_API_SERVER_ADDRESS + "users" + "/:id/authenticated"
+                    url: env.FM_API_SERVER_ADDRESS + "users/authenticated"
                 },
                 stats: {
                     method: "GET",

--- a/app/js/auth/services/SpotifyAuthService.js
+++ b/app/js/auth/services/SpotifyAuthService.js
@@ -139,13 +139,13 @@ angular.module("FM.auth.SpotifyAuthService", [
         this.getUser = function getUser() {
             var deferred = $q.defer();
 
-            _this.authenticate()
-                .then(function (){
-                    getCurrentUser()
-                        .then(deferred.resolve)
-                        .catch(deferred.reject);
-                })
-                .catch(deferred.reject);
+            if (authenticated){
+                getCurrentUser()
+                    .then(deferred.resolve)
+                    .catch(deferred.reject);
+            } else {
+                deferred.reject();
+            }
 
             return deferred.promise;
         };

--- a/app/js/auth/services/SpotifyAuthService.js
+++ b/app/js/auth/services/SpotifyAuthService.js
@@ -12,16 +12,6 @@ angular.module("FM.auth.SpotifyAuthService", [
     "spotify"
 ])
 /**
- * @method run
- * @param  {Service} SpotifyAuth
- */
-.run([
-    "SpotifyAuth",
-    function (SpotifyAuth){
-        SpotifyAuth.init();
-    }
-])
-/**
  * @constant
  * @property {String} TOKEN_NAME
  */
@@ -112,49 +102,20 @@ angular.module("FM.auth.SpotifyAuthService", [
          * Authenticate with spotify OAuth
          * @public
          * @method authenticate
-         * @param  {Boolean} onlyIfToken only request auth if user token exists
          * @return {Object}  Spotify     user object
          */
-        this.authenticate = function authenticate(onlyIfToken) {
-            var deferred = $q.defer(),
-                authToken = $window.localStorage.getItem(TOKEN_NAME);
+        this.authenticate = function authenticate() {
+            var deferred = $q.defer();
 
-            // check for existing auth token
-            if (authToken){
-                Spotify.setAuthToken(authToken);
-
-                getCurrentUser()
-                    .then(function (){
-                        authenticated = true;
-                        deferred.resolve(authToken);
-                    })
-                    .catch(function (){
-                        login()
-                            .then(function (response){
-                                authenticated = true;
-                                deferred.resolve(response);
-                            })
-                            .catch(function (response){
-                                authenticated = false;
-                                deferred.reject(response);
-                            });
-                    });
-
-            } else {
-                if (!onlyIfToken){
-                    login()
-                        .then(function (response){
-                            authenticated = true;
-                            deferred.resolve(response);
-                        })
-                        .catch(function (response){
-                            authenticated = false;
-                            deferred.reject(response);
-                        });
-                } else {
-                    deferred.reject();
-                }
-            }
+            login()
+                .then(function (response){
+                    authenticated = true;
+                    deferred.resolve(response);
+                })
+                .catch(function (response){
+                    authenticated = false;
+                    deferred.reject(response);
+                });
 
             return deferred.promise;
         };
@@ -178,7 +139,7 @@ angular.module("FM.auth.SpotifyAuthService", [
         this.getUser = function getUser() {
             var deferred = $q.defer();
 
-            _this.authenticate(true)
+            _this.authenticate()
                 .then(function (){
                     getCurrentUser()
                         .then(deferred.resolve)
@@ -208,16 +169,6 @@ angular.module("FM.auth.SpotifyAuthService", [
                 .catch(deferred.reject);
 
             return deferred.promise;
-        };
-
-        /**
-         * Attempt to authenicate the user if
-         * they have logged into spotify before
-         * @public
-         * @method init
-         */
-        this.init = function init() {
-            _this.authenticate(true);
         };
 
     }

--- a/app/js/users/controllers/UserPlaylistsCtrl.js
+++ b/app/js/users/controllers/UserPlaylistsCtrl.js
@@ -48,14 +48,6 @@ angular.module("FM.users.UserPlaylistsCtrl", [
     function ($scope, Spotify, SpotifyAuth, user, env) {
 
         /**
-         * @property SpotifyAuth
-         * @type {Object}
-         */
-        $scope.authenticated = function authenticated(){
-            return SpotifyAuth.isAuthenticated();
-        };
-
-        /**
          * @property {Object} user
          */
         $scope.user = user;
@@ -78,6 +70,14 @@ angular.module("FM.users.UserPlaylistsCtrl", [
          * @type {Boolean}
          */
         $scope.loadDisabled = false;
+
+        /**
+         * @property SpotifyAuth
+         * @type {Object}
+         */
+        $scope.authenticated = function authenticated(){
+            return SpotifyAuth.isAuthenticated();
+        };
 
         /**
          * Load more search results
@@ -110,7 +110,7 @@ angular.module("FM.users.UserPlaylistsCtrl", [
             }
         };
 
-        $scope.$watch("authenticated", $scope.onAuthChange);
+        $scope.$watch($scope.authenticated, $scope.onAuthChange);
 
     }
 ]);

--- a/app/js/users/controllers/UserPlaylistsCtrl.js
+++ b/app/js/users/controllers/UserPlaylistsCtrl.js
@@ -18,12 +18,12 @@ angular.module("FM.users.UserPlaylistsCtrl", [
     function ($routeProvider) {
 
         $routeProvider
-            .when("/users/me/playlists", {
+            .when("/users/:id/playlists", {
                 templateUrl: "partials/users/playlists.html",
                 controller: "UserPlaylistsCtrl",
                 resolve: {
-                    user: ["UsersResource", function (UsersResource){
-                        return UsersResource.current().$promise;
+                    user: ["UsersResource", "$route", function (UsersResource, $route){
+                        return UsersResource.get($route.current.params).$promise;
                     }]
                 }
             });

--- a/app/partials/header.html
+++ b/app/partials/header.html
@@ -18,14 +18,6 @@
                 </button>
             </span>
 
-            <span class="hidden-xs" ng-show="!isAuthenticated()" ng-controller="LoginSpotifyCtrl">
-                <button type="button" class="btn btn-spotify" ng-click="authenticate()">
-                    <span class="icon icon-spotify h4"></span>
-                    <span class="separator"></span>
-                    Login to Spotify
-                </button>
-            </span>
-
             <span ng-if="isAuthenticatedGoogle()">
                 <button class="btn btn-link hidden-lg hidden-md" ng-click="toogleSidebar()">
                     <span class="h3 icon icon-playlist-add text-muted"></span>

--- a/app/partials/users/nav.html
+++ b/app/partials/users/nav.html
@@ -7,10 +7,11 @@
             <a ng-href="./users/{{ user.id }}">Stats</a>
         </li>
         <li role="presentation"
+            ng-if="currentUser.id === user.id"
             ng-class="{
-                'active': routeIsActive('/users/me/playlists')
+                'active': routeIsActive('/users/' + user.id + '/playlists')
             }">
-            <a ng-href="./users/me/playlists">Playlists</a>
+            <a ng-href="./users/{{ user.id }}/playlists">Playlists</a>
         </li>
     </ul>
 </nav>

--- a/app/partials/users/nav.html
+++ b/app/partials/users/nav.html
@@ -7,12 +7,10 @@
             <a ng-href="./users/{{ user.id }}">Stats</a>
         </li>
         <li role="presentation"
-            ng-if="currentUser.id === user.id"
-            ng-controller="LoginSpotifyCtrl"
             ng-class="{
-                'active': routeIsActive('/users/' + user.id + '/playlists')
+                'active': routeIsActive('/users/me/playlists')
             }">
-            <a ng-if="isAuthenticated()" ng-href="./users/{{ user.id }}/playlists">Playlists</a>
+            <a ng-href="./users/me/playlists">Playlists</a>
         </li>
     </ul>
 </nav>

--- a/app/partials/users/playlists.html
+++ b/app/partials/users/playlists.html
@@ -2,7 +2,7 @@
 
 <div ng-include="'partials/users/nav.html'"></div>
 
-<div class="container-fluid">
+<div class="container-fluid" ng-if="authenticated()">
     <div class="row">
         <div class="col-xs-12">
             <h2>Playlists <span class="badge">{{ meta.total }}</span></h2>
@@ -21,6 +21,24 @@
         <div class="col-xs-12 text-center">
             <button class="btn btn-primary" ng-click="loadMore()" ng-if="meta.next" ng-disabled="loadDisabled">Load more</button>
             <p ng-if="meta.total > 0 && !meta.next">No more playlists</p>
+        </div>
+    </div>
+</div>
+
+<div class="container-fluid" ng-if="!authenticated()">
+    <div class="row">
+        <div class="col-xs-12">
+
+            <h2>Click the button below to login to Spotify and view your playlists</h2>
+
+        </div>
+
+        <div class="col-xs-12 text-center" ng-controller="LoginSpotifyCtrl">
+            <button type="button" class="btn btn-spotify" ng-click="authenticate()">
+                <span class="icon icon-spotify h4"></span>
+                <span class="separator"></span>
+                Login to Spotify
+            </button>
         </div>
     </div>
 </div>

--- a/app/partials/users/playlists.html
+++ b/app/partials/users/playlists.html
@@ -17,6 +17,8 @@
         </li>
     </ul>
 
+    <img ng-show="loadDisabled" class="center-block loading-animation" src="img/icons/loading-animation.gif" width="50">
+
     <div class="row">
         <div class="col-xs-12 text-center">
             <button class="btn btn-primary" ng-click="loadMore()" ng-if="meta.next" ng-disabled="loadDisabled">Load more</button>

--- a/tests/unit/auth/services/SpotifyAuthService.js
+++ b/tests/unit/auth/services/SpotifyAuthService.js
@@ -79,11 +79,8 @@ describe("FM.auth.SpotifyAuthService", function() {
     it("should return authentication status", function () {
         var authenticated = service.isAuthenticated();
         expect(authenticated).toBeFalsy();
-        token = "foo";
 
-        service.getUser();
-
-        $httpBackend.flush();
+        service.authenticate();
         $rootScope.$digest();
 
         authenticated = service.isAuthenticated();
@@ -130,6 +127,9 @@ describe("FM.auth.SpotifyAuthService", function() {
     it("should get the current user", function () {
         var data;
 
+        service.authenticate();
+        $rootScope.$digest();
+
         service.getUser()
             .then(function (response){
                 data = response;
@@ -144,9 +144,21 @@ describe("FM.auth.SpotifyAuthService", function() {
 
     it("should handle error when getting current user", function () {
         var data;
-        token = "foo";
+
+        service.getUser()
+            .then(function (response){
+                data = response;
+            });
+
+        expect(data).not.toBe(user);
+
+        service.authenticate();
+        $rootScope.$digest();
 
         userRequest.respond(200, { error: { status: 401 }});
+
+        service.authenticate();
+        $rootScope.$digest();
 
         service.getUser()
             .then(function (response){
@@ -161,6 +173,9 @@ describe("FM.auth.SpotifyAuthService", function() {
 
     it("should get users playlist", function () {
         var data;
+
+        service.authenticate();
+        $rootScope.$digest();
 
         service.getUserPlaylists()
             .then(function (response){

--- a/tests/unit/auth/services/SpotifyAuthService.js
+++ b/tests/unit/auth/services/SpotifyAuthService.js
@@ -75,71 +75,6 @@ describe("FM.auth.SpotifyAuthService", function() {
         $httpBackend.verifyNoOutstandingRequest();
     });
 
-    it("should attempt to get current user if auth token exists", function () {
-        var setAuthTokenSpy = spyOn(Spotify, "setAuthToken");
-        token = "foo";
-
-        service.init();
-        $httpBackend.flush();
-        $rootScope.$digest();
-
-        expect(setAuthTokenSpy).toHaveBeenCalledWith(token);
-        expect(Spotify.getCurrentUser).toHaveBeenCalled();
-    });
-
-    it("should NOT attempt to get current user if auth token doesn't exists", function () {
-        var setAuthTokenSpy = spyOn(Spotify, "setAuthToken");
-        getItemSpy.and.callFake(function(){ return null });
-
-        service.init();
-        $rootScope.$digest();
-        expect(setAuthTokenSpy).not.toHaveBeenCalled();
-        expect(Spotify.getCurrentUser).not.toHaveBeenCalled();
-    });
-
-    it("should authenticate the user if token has expired", function () {
-        var setAuthTokenSpy = spyOn(Spotify, "setAuthToken");
-
-        user = { error: { status: 401 } };
-        userRequest.respond(200, user);
-        token = "foo";
-
-        service.init();
-        $httpBackend.flush();
-        $rootScope.$digest();
-
-        expect(setAuthTokenSpy).toHaveBeenCalled();
-        expect(Spotify.getCurrentUser).toHaveBeenCalled();
-
-        user = { error: { status: 401 } };
-        userRequest.respond(401, user);
-
-        service.init();
-        $httpBackend.flush();
-        $rootScope.$digest();
-
-        expect(setAuthTokenSpy.calls.count()).toEqual(3);
-        expect(Spotify.getCurrentUser.calls.count()).toEqual(2);
-
-        spotifyLoginResponse = { error: { status: 401 } };
-
-        service.init();
-        $httpBackend.flush();
-        $rootScope.$digest();
-
-        expect(setAuthTokenSpy.calls.count()).toEqual(4);
-        expect(Spotify.getCurrentUser.calls.count()).toEqual(3);
-
-        user = { error: { status: 404 } };
-        userRequest.respond(404, user);
-
-        service.init();
-        $httpBackend.flush();
-        $rootScope.$digest();
-
-        expect(setAuthTokenSpy.calls.count()).toEqual(5);
-        expect(Spotify.getCurrentUser.calls.count()).toEqual(4);
-    });
 
     it("should return authentication status", function () {
         var authenticated = service.isAuthenticated();
@@ -156,79 +91,43 @@ describe("FM.auth.SpotifyAuthService", function() {
     });
 
     it("should attempt to authenticate user", function () {
-        token = "foo";
         var setAuthTokenSpy = spyOn(Spotify, "setAuthToken");
+        spotifyLoginResponse = "foo";
         service.authenticate();
-        $httpBackend.flush();
         $rootScope.$digest();
 
-        expect(setAuthTokenSpy).toHaveBeenCalledWith(token);
+        expect(setAuthTokenSpy).toHaveBeenCalledWith(spotifyLoginResponse);
         expect(service.isAuthenticated()).toBeTruthy();
     });
 
     it("should attempt to authenticate user and handle error", function () {
         // user has local token, token is expired, token is renewed
         var error = { error: { status: 401 } };
-        token = "foo";
-        userRequest.respond(200, error);
-        var setAuthTokenSpy = spyOn(Spotify, "setAuthToken");
         var alertSpy = spyOn(AlertService, "set");
 
-        service.authenticate();
-        $httpBackend.flush();
-        $rootScope.$digest();
-
-        expect(setAuthTokenSpy.calls.count()).toBe(2);
-        expect($window.localStorage.setItem.calls.count()).toBe(1);
-        expect(service.isAuthenticated()).toBeTruthy();
-
-        // user has local token, token is still valid
-        userRequest.respond(200, user);
-
-        service.authenticate();
-        $httpBackend.flush();
-        $rootScope.$digest();
-
-        expect(setAuthTokenSpy.calls.count()).toBe(3);
-        expect($window.localStorage.setItem.calls.count()).toBe(1);
-        expect(service.isAuthenticated()).toBeTruthy();
-
-        // user has local token, token is expired, token renewal fails
-        userRequest.respond(200, error);
         spotifyLoginResponse = error;
 
-        service.authenticate();
-        $httpBackend.flush();
-        $rootScope.$digest();
-
-        expect(setAuthTokenSpy.calls.count()).toBe(4);
-        expect($window.localStorage.setItem.calls.count()).toBe(1);
-        expect(service.isAuthenticated()).toBeFalsy();
-
-        // user does NOT have local token, user authentication fails
-        spotifyLoginResponse = { error: { status: 401 } };
-        token = undefined;
-
+        // login fails
         service.authenticate();
         $rootScope.$digest();
 
-        expect(setAuthTokenSpy.calls.count()).toBe(4);
-        expect($window.localStorage.setItem.calls.count()).toBe(1);
+        expect(setItemSpy).not.toHaveBeenCalled();
+        expect(removeItemSpy).toHaveBeenCalled();
+        expect($window.localStorage.setItem).not.toHaveBeenCalled();
         expect(service.isAuthenticated()).toBeFalsy();
 
-        // user does NOT have local token, user authentication successful
+        // login successful
         spotifyLoginResponse = "bar";
 
         service.authenticate();
         $rootScope.$digest();
 
-        expect(setAuthTokenSpy.calls.count()).toBe(5);
-        expect($window.localStorage.setItem.calls.count()).toBe(2);
+        expect(setItemSpy).toHaveBeenCalled();
+        expect($window.localStorage.setItem).toHaveBeenCalled();
         expect(service.isAuthenticated()).toBeTruthy();
     });
 
     it("should get the current user", function () {
-        token = "foo";
         var data;
 
         service.getUser()
@@ -244,10 +143,10 @@ describe("FM.auth.SpotifyAuthService", function() {
     });
 
     it("should handle error when getting current user", function () {
-        token = "foo";
         var data;
+        token = "foo";
 
-        userRequest.respond(400, { error: { status: 401 }});
+        userRequest.respond(200, { error: { status: 401 }});
 
         service.getUser()
             .then(function (response){
@@ -256,11 +155,11 @@ describe("FM.auth.SpotifyAuthService", function() {
 
         $httpBackend.flush();
         $rootScope.$digest();
+
         expect(data).not.toBe(user);
     });
 
     it("should get users playlist", function () {
-        token = "foo";
         var data;
 
         service.getUserPlaylists()
@@ -272,5 +171,6 @@ describe("FM.auth.SpotifyAuthService", function() {
         $rootScope.$digest();
         expect(data).toEqual(playlists);
     });
+
 
 });

--- a/tests/unit/users/controllers/UserPlaylistsCtrl.js
+++ b/tests/unit/users/controllers/UserPlaylistsCtrl.js
@@ -29,7 +29,7 @@ describe("FM.users.UserPlaylistsCtrl", function() {
         $httpBackend.whenGET(/partials\/.*/).respond(200, "");
         $httpBackend.whenGET(/api.spotify.com\/v1\/users\/.*\/playlists/).respond(200, playlistsResponse);
         $httpBackend.whenGET(/api.spotify.com\/v1\/users\/.*/).respond(200, userResponse);
-        $httpBackend.whenGET(env.FM_API_SERVER_ADDRESS + "users/foo").respond(200, userResponse);
+        $httpBackend.whenGET(env.FM_API_SERVER_ADDRESS + "users/authenticated").respond(200, userResponse);
     }));
 
     beforeEach(inject(function (  _$location_, _$route_, _$rootScope_, $injector, $controller ) {
@@ -72,7 +72,7 @@ describe("FM.users.UserPlaylistsCtrl", function() {
     });
 
     it("should load user playlist view", function() {
-        $location.path("/users/foo/playlists/");
+        $location.path("/users/me/playlists/");
         $rootScope.$digest();
         $httpBackend.flush();
         expect($route.current.controller).toBe("UserPlaylistsCtrl");

--- a/tests/unit/users/controllers/UserPlaylistsCtrl.js
+++ b/tests/unit/users/controllers/UserPlaylistsCtrl.js
@@ -29,7 +29,7 @@ describe("FM.users.UserPlaylistsCtrl", function() {
         $httpBackend.whenGET(/partials\/.*/).respond(200, "");
         $httpBackend.whenGET(/api.spotify.com\/v1\/users\/.*\/playlists/).respond(200, playlistsResponse);
         $httpBackend.whenGET(/api.spotify.com\/v1\/users\/.*/).respond(200, userResponse);
-        $httpBackend.whenGET(env.FM_API_SERVER_ADDRESS + "users/authenticated").respond(200, userResponse);
+        $httpBackend.whenGET(env.FM_API_SERVER_ADDRESS + "users/foo").respond(200, userResponse);
     }));
 
     beforeEach(inject(function (  _$location_, _$route_, _$rootScope_, $injector, $controller ) {
@@ -74,7 +74,7 @@ describe("FM.users.UserPlaylistsCtrl", function() {
     });
 
     it("should load user playlist view", function() {
-        $location.path("/users/me/playlists/");
+        $location.path("/users/foo/playlists/");
         $httpBackend.flush();
         $rootScope.$digest();
         expect($route.current.controller).toBe("UserPlaylistsCtrl");


### PR DESCRIPTION
So this should be a temporary solution, the user will have to manually click to login to spotify when on their own profile playlists page.

This should stop the error message that appear when the user navigates to the player and their token has expired.

Fixes #211 