### PR TITLE
Fix: Track not added to playlist

### DIFF
--- a/app/js/playlist/controllers/PlaylistCtrl.js
+++ b/app/js/playlist/controllers/PlaylistCtrl.js
@@ -81,7 +81,7 @@ angular.module("FM.playlist.PlaylistCtrl", [
         $scope.page = {
             loading: false,
             pages: 1,
-            total: playlistData.meta.totalPages
+            total: playlistData.meta.totalPages || 1
         };
 
         /**


### PR DESCRIPTION
Fixed an issue where if there are no items in the playlist and a track gets added it would not be added to the playlist until the page was refreshed.

The issue was that when there are no items in the queue the API didn't return total pages pagination data in the header which broke some logic in the FE.

Fixes #199 