### PR TITLE
Feature: Frontend backend config

### DIFF
--- a/env.json
+++ b/env.json
@@ -40,5 +40,19 @@
         "SPOTIFY_CLIENT_ID": "706dc770a95f4b83b60b72b79d6e818f",
         "SPOTIFY_REDIRECT_URI": "https://thisissoon.fm/partials/spotify-login.html",
         "SPOTIFY_SCOPE": "user-read-private playlist-read-private playlist-modify-private playlist-modify-public"
+    },
+    "frontend-api": {
+        "BASE_URL": "/",
+        "GOOGLE_REDIRECT_URI": "http://localhost:1337/",
+        "FM_API_SERVER_ADDRESS": "/api/",
+        "FM_SOCKET_ADDRESS": "http://localdocker:8080",
+        "HTML5_LOCATION": true,
+        "GOOGLE_CLIENT_ID": "999522755620-kiiv5l08jf9ummob1iqveokd373r3r60.apps.googleusercontent.com",
+        "REGION_CODE": "GB",
+        "SEARCH_LIMIT": 20,
+        "SIDEBAR_SEARCH_LIMIT": 3,
+        "SPOTIFY_CLIENT_ID": "706dc770a95f4b83b60b72b79d6e818f",
+        "SPOTIFY_REDIRECT_URI": "http://localhost:1337/partials/spotify-login.html",
+        "SPOTIFY_SCOPE": "user-read-private playlist-read-private playlist-modify-private playlist-modify-public"
     }
 }


### PR DESCRIPTION
This PR adds a config to build the FE to work with the new Frontend API.

To build simply run: `grunt build --env frontend-api`

### Notes
- Eventually I'd imagine this will become the default for `development`
- Sockets still run in the API so for now the api would still need to be running in another service