### PR TITLE
Feature: sails socket

### DIFF
--- a/app/js/socket/factories/PlayerQueueSocket.js
+++ b/app/js/socket/factories/PlayerQueueSocket.js
@@ -1,0 +1,24 @@
+"use strict";
+/**
+ * Factory which provides methods for communicating with the FM FE API
+ * /player/queue endpoint
+ * @module FM.socket.sails.PlayerQueueSocket
+ * @author SOON_
+ */
+angular.module("FM.socket.sails.PlayerQueueSocket", [
+
+])
+/**
+ * @constructor
+ * @class PlayerQueueSocket
+ * @param {Service} $sailsSocket
+ * @param {Object}  env
+ */
+.factory("PlayerQueueSocket", [
+    "sailsResource",
+    function (sailsResource) {
+
+        return new sailsResource("/player/queue");
+
+    }
+]);

--- a/app/js/socket/sails.js
+++ b/app/js/socket/sails.js
@@ -1,0 +1,64 @@
+"use strict";
+/**
+ * @module FM.sockets.sails
+ * @author SOON_
+ */
+angular.module("FM.sockets.sails", [
+    "FM.socket.sails.PlayerQueueSocket",
+    "config",
+    "angularSails.io"
+])
+
+.factory("sailsSocket", [
+    "$sailsSocket",
+    "env",
+    function ($sailsSocket, env) {
+
+      return $sailsSocket({ baseUrl: "http://localhost:1337" });
+
+    }
+])
+
+.factory("sailsResource", [
+    "sailsSocket",
+    function (sailsSocket) {
+
+        var SailsResource = function SailsResource (identity, options) {
+            options = options || {};
+            identity = identity.replace(/^\/|\/$/g, '');
+
+            var prefix = options.prefix || "/api/";
+
+            this.url = prefix + identity;
+            this.event = identity;
+            this.baseUrl = sailsSocket._socketOptions.baseUrl;
+        };
+
+        SailsResource.prototype.get = function getResource (options) {
+            var self = this;
+            return sailsSocket.get(self.url, options);
+        };
+
+        SailsResource.prototype.save = function deleteResource (options) {
+            var self = this;
+            return sailsSocket.post(self.url, options);
+        };
+
+        SailsResource.prototype.remove = function deleteResource (options) {
+            var self = this;
+            return sailsSocket.delete(self.url, options);
+        };
+
+        SailsResource.prototype.on = function on (event, handler) {
+            var self = this;
+
+            return sailsSocket.on(self.event, function (message) {
+                if (event === message.verb) {
+                    handler.apply(this, [message.verb, message.data]);
+                }
+            });
+        };
+
+        return SailsResource;
+    }
+]);

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,8 @@
     "d3": "3.3.13",
     "angular-chart.js": "0.7.1",
     "Chart.js": "1.0.2",
-    "angular-sn-infinite-scroll": "0.1.0"
+    "angular-sn-infinite-scroll": "0.1.0",
+    "angularSails": "0.12.1"
   },
   "devDependencies": {
     "angular-mocks": "1.3.17"

--- a/modules/index.html
+++ b/modules/index.html
@@ -50,6 +50,7 @@
                         <h2>JS Modules</h2>
                             <li><a class="btn btn-primary" href="search/">Search</a></li>
                             <li><a class="btn btn-primary" href="visualisation/">Visualisation</a></li>
+                            <li><a class="btn btn-primary" href="socket/sails.html">Sails socket</a></li>
                         <ul>
 
                         </ul>

--- a/modules/socket/sails.html
+++ b/modules/socket/sails.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en" ng-app="socketDemo">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <title>SOON FM_ - Modules</title>
+
+    <base href="/app/">
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:400,700" type="text/css">
+    <link rel="stylesheet" href="css/all.css">
+
+</head>
+
+<body ng-controller="SocketDemoCtrl">
+
+    <div ng-repeat="item in queue">
+        {{ item }}
+    </div>
+
+    <script src="components/angular/angular.js"></script>
+    <script src="components/socket.io-client/socket.io.js"></script>
+    <script src="components/angularSails/dist/ngsails.io.js"></script>
+
+    <script src="js/config/config.js"></script>
+
+    <script src="js/socket/sails.js"></script>
+    <script src="js/socket/factories/PlayerQueueSocket.js"></script>
+
+    <script>
+        angular.module("socketDemo", [
+            "FM.sockets.sails"
+        ])
+        .controller("SocketDemoCtrl", [
+            "$scope",
+            "PlayerQueueSocket",
+            function ($scope, PlayerQueueSocket) {
+
+                $scope.queue = [];
+
+                PlayerQueueSocket.get()
+                    .then(function (response) {
+                        $scope.queue = response.data;
+                    });
+
+                PlayerQueueSocket.on("created", function (event, data) {
+                    $scope.queue.unshift(data);
+                });
+
+            }
+        ]);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a prototype module for testing sails socket connectivity. This uses the [angualrSails](https://github.com/balderdashy/angularSails) module for sails angular bindings. This library alone would allow us to make requests like this:
```
sailsSocket.get("/player/queue").then...
```
and handle events like this:
```
sailsSocket.on("player/queue", function(message){
  switch(message.verb){
    case "created":
    ...
    // check which event occured and respond accordingly
  }
})
```

This library is structured similarly to $http however I felt we might prefer an approach similar to how we use $resource, so I have begun to investigate this through a `sailsResource` factory. This would allow us to have a resource like [PlayerQueueSocket](https://github.com/thisissoon/FM-Frontend/compare/feature/sails-socket?expand=1#diff-4b8c37597b1d211263e183536ea8b524R21) and make requests like:
```
PlayerQueueSocket.get().then...
```
and handle events like:
```
PlayerQueueSocket.on("created", function (event, data) {
  $scope.queue.unshift(data);
})
```

Check out the demo at `/modules/socket/sails.html`