### PR TITLE
Fix: add track from user stats page

### DIFF
--- a/app/js/player/directives/track.js
+++ b/app/js/player/directives/track.js
@@ -95,8 +95,8 @@ angular.module("FM.player.trackDirective", [
                  * @param {Object} track
                  */
                 $scope.addToPlaylist = function addToPlaylist (track) {
-                    if (track && track.uri) {
-                        PlayerQueueResource.save({ uri: track.uri });
+                    if (track && (track.uri || track.spotify_uri)) { //jshint ignore:line
+                        PlayerQueueResource.save({ uri: track.uri || track.spotify_uri }); //jshint ignore:line
                     }
                 };
 

--- a/tests/unit/player/directives/track.js
+++ b/tests/unit/player/directives/track.js
@@ -64,6 +64,14 @@ describe("FM.player.trackDirective", function() {
     it("should add track to playlist", function(){
         isolatedScope.addToPlaylist({ uri: "123" });
         expect(PlayerQueueResource.save).toHaveBeenCalledWith({ uri: "123" });
+
+        isolatedScope.addToPlaylist({ spotify_uri: "456" });
+        expect(PlayerQueueResource.save.calls.argsFor(1)).toEqual([{ uri: "456" }]);
+    })
+
+    it("should NOT add track to playlist", function(){
+        isolatedScope.addToPlaylist({ uri: undefined });
+        expect(PlayerQueueResource.save).not.toHaveBeenCalled();
     })
 
     it("should remove track from playlist", function(){


### PR DESCRIPTION
This was because the api was returning the `uri` in the track object as `spotify_uri` instead of just `uri` as it is everywhere else in the api.

I updated the track directive to work with both

Fixes #237 